### PR TITLE
fix for with's prolonged effect

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -171,10 +171,12 @@ class Command(object):
         else: return self.path
 
     def __enter__(self):
-        self.prepend_stack.append([self.path])
+        if not self.call_args["with"]:
+            Command.prepend_stack.append([self.path])
 
     def __exit__(self, typ, value, traceback):
-        self.prepend_stack.pop()
+        if Command.prepend_stack != []:
+            Command.prepend_stack.pop()
 
     def __call__(self, *args, **kwargs):
         kwargs = kwargs.copy()


### PR DESCRIPTION
I was testing the examples from readme (copy-pasted them in one single file) and I noticed that this code:

```
with sudo(p=">", _with=True):
    print ls("/root")
```

also prepended every following command in a script (outside of `with` statement) with sudo.

I've replaced the body of Command's `enter` and `exit` methods; the problem was that commands were appended to an object's `prepend_stack` rather than to the one of the class.

I've tested the fix with the following code:

```
from pbs import *

with sudo(p='> ', _with=True):
    print ls('/root')
    print ls('/root', a=True)

try:
    print ls('/root')
    print "doesn't work"
except ErrorReturnCode_2:
    print "works"

with sudo:
    print ls(HOME)
    print ls(HOME, a=True)
    with bash(c=True, _with=True):
        print ls(HOME) # bash -c ls <anything> == ls
```

But I haven't checked closely if this "fix" introduced any new bugs. I hope this helps.
