### PR TITLE
fix importing from IPython

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -413,7 +413,7 @@ else:
 
 
     # are we being imported from a REPL? don't allow
-    if script == "<stdin>":
+    if script == "<stdin>" or script == "<ipython console>":
         self = sys.modules[__name__]
         sys.modules[__name__] = SelfWrapper(self)
         


### PR DESCRIPTION
[IPython](http://ipython.org/) defines script name as `<ipython console>` instead of `<stdin>` so importing pbs didn't work. I've added this as a special case.
