### PR TITLE
Fixed argument passing of space

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -292,20 +292,23 @@ class Command(object):
             # we're passing a short arg as a kwarg, example:
             # cut(d="\t")
             if len(k) == 1:
-                if v is True: arg = "-"+k
-                else: arg = "-%s %r" % (k, v)
+                if v is True: 
+                    processed_args.append("-"+k)
+                else:
+                    processed_args.append('-'+k)
+                    processed_args.append(v)
 
             # we're doing a long arg
             else:
                 k = k.replace("_", "-")
 
-                if v is True: arg = "--"+k
-                else: arg = "--%s=%s" % (k, v)
-            processed_args.append(arg)
+                if v is True: 
+                    processed_args.append("--"+k)
+                else:
+                    processed_args.append("--"+k)
+                    processed_args.append(v)
 
-        processed_args = shlex.split(" ".join(processed_args))
         return processed_args
- 
     
     def bake(self, *args, **kwargs):
         fn = Command(self._path)

--- a/test.py
+++ b/test.py
@@ -60,6 +60,12 @@ class PbsTestSuite(unittest.TestCase):
         from pbs import sed, echo
         out = unicode(sed(echo("test"), expression="s/test/lol/")).strip()
         self.assertEqual(out, "lol")
+
+    @requires_posix
+    def test_long_option_space_argument(self):
+        from pbs import sed, echo
+        out = unicode(sed(echo("test test"), expression="s/test test/lol lol/")).strip()
+        self.assertEqual(out, "lol lol")
         
     @requires_posix
     def test_command_wrapper(self):


### PR DESCRIPTION
pbs does not support arguments with spaces eg

import pbs.sed
sed(expression='s/test test/lol lol')

breaks
