### PR TITLE
line 195 in wait() was missing an argument. fixed to match similar line 137

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -192,7 +192,7 @@ class RunningCommand(object):
         self._stdout, self._stderr = self.process.communicate()
         rc = self.process.wait()
 
-        if rc != 0: raise get_rc_exc(rc)(self.stdout, self.stderr)
+        if rc != 0: raise get_rc_exc(rc)(self.command_ran, self._stdout, self._stderr)
         return self
     
     def __len__(self):


### PR DESCRIPTION
self.command_ran is missing from the argument list on line 195, leading to errors like this:

```
  File "/usr/local/lib/python2.6/dist-packages/pbs.py", line 195, in wait
    if rc != 0: raise get_rc_exc(rc)(self.stdout, self.stderr)
TypeError: __init__() takes exactly 4 arguments (3 given)
```

if a background process returns a non-zero.

I changed it to match the similar line in __init__(), line 137, and now it works as expected.
