### PR TITLE
re-add pbs.glob

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -27,6 +27,7 @@ import sys
 import traceback
 import os
 import re
+from glob import glob       # expose pbs.glob
 import shlex
 from types import ModuleType
 from functools import partial


### PR DESCRIPTION
Small change. Looks like this got removed as a "minor pyflakes fix" since it's "unused" as far as static analysis can tell.
