### PR TITLE
Test for coercing backgrounded process to int

### DIFF
--- a/test.py
+++ b/test.py
@@ -259,6 +259,13 @@ print len(options.long_option.split())
         self.assertTrue(now - start > sleep_time)
                 
     
+    def test_bg_to_int(self):
+        from pbs import echo
+        # bugs with background might cause the following error:
+        #   ValueError: invalid literal for int() with base 10: ''
+        self.assertEqual(int(echo("123", _bg=True)), 123)
+
+
     def test_with_context(self):
         from pbs import time, ls
         with time:


### PR DESCRIPTION
The README example of curling github in the background fails because __unicode__ never calls p.wait(). We probably want to add the standard `if self.call_args["bg"]: self.wait()` into RunningCommand.__unicode__, but things like

```
>>> pbs.sleep(3, _bg=True)
```

might surprise people by running in the foreground since repr is called right off the bat.
