### PR TITLE
Script to rename 'pbs' to 'sh' for dual-releases.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@
 * Arjen Stolk
 * nemec
 * fruch
+* Ralph Bean

--- a/mvnamespace.py
+++ b/mvnamespace.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+""" mvnamespace.py -- Rename the pbs module to 'sh'.
+
+Use this script for releases.  So that http://pypi.python.org/pypi/sh can stay
+in sync with http://pypi.python.org/pypi/pbs.
+
+See the discussion in https://github.com/amoffat/pbs/issues/28 for more
+information.
+"""
+
+import os
+
+TARGET_DIR = os.path.abspath('sh')
+file_mapping = {
+    "pbs.py": "%s/sh.py" % TARGET_DIR,
+    "test.py": "%s/test.py" % TARGET_DIR,
+    "setup.py": "%s/setup.py" % TARGET_DIR,
+    "README.md": "%s/README.md" % TARGET_DIR,
+    "AUTHORS.md": "%s/AUTHORS.md" % TARGET_DIR,
+    "LICENSE.txt": "%s/LICENSE.txt" % TARGET_DIR,
+    "MANIFEST.in": "%s/MANIFEST.in" % TARGET_DIR,
+}
+
+
+def replace(content):
+    return content\
+            .replace('pbs', 'sh')\
+            .replace('PBS ', '``sh`` ')
+
+
+def main():
+    if os.path.exists(TARGET_DIR):
+        raise IOError("Target %r already exists.  Aborting." % TARGET_DIR)
+
+    os.mkdir(TARGET_DIR)
+
+    for frm, to in file_mapping.items():
+        with open(frm, 'r') as from_file:
+            with open(to, 'w') as to_file:
+                print "Writing %r" % to
+                to_file.write(replace(from_file.read()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
As talked about in issue #28, Fedora can't package this (much cooler) pbs so long as it and the other pbs share a name conflict.  @agrover's approach of renaming the RPM to python-sh but keeping the module namespace won't work out; if both pbs modules are installed, what will `import pbs` actually import?  See the [package review](https://bugzilla.redhat.com/show_bug.cgi?id=808258) for more details.

---

The script in this pull request just copies all the files to a `sh/` directory and does a dumb search-replace on them.  Surprisingly, it works (the test suite does, at least).

Since `sh` is [squatted](http://pypi.python.org/pypi/sh), each time you do a new release of `pbs`, you could run this script and also put up a release of `sh` all while avoiding the thorny task of maintaining two codebases.
