### PR TITLE
Add cwd to the list of call arguments

### DIFF
--- a/pbs.py
+++ b/pbs.py
@@ -229,6 +229,7 @@ class Command(object):
         "err_to_out": None, # redirect STDERR to STDOUT
         "in": None,
         "env": os.environ,
+        "cwd": None,
 
         # this is for commands that may have a different exit status than the
         # normal 0.  this can either be an integer or a list/tuple of ints
@@ -427,7 +428,7 @@ If you're using glob.glob(), please use pbs.glob() instead." % self.path, stackl
 
         # leave shell=False
         process = subp.Popen(cmd, shell=False, env=call_args["env"],
-            stdin=stdin, stdout=stdout, stderr=stderr)
+            cwd=call_args["cwd"], stdin=stdin, stdout=stdout, stderr=stderr)
 
         return RunningCommand(command_ran, process, call_args, actual_stdin)
 

--- a/test.py
+++ b/test.py
@@ -377,7 +377,10 @@ print len(options.long_option.split())
 
         self.assertEqual(iam1, iam2)
 
-
+    def test_cwd(self):
+        from pbs import pwd
+        self.assertEqual(str(pwd(_cwd='/tmp')), '/tmp\n')
+        self.assertEqual(str(pwd(_cwd='/etc')), '/etc\n')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey Andrew,

Thank you for the really great utility, it helps me a lot in many cases. This changeset adds one more argument "_cwd" to pbs calls. Please consider pulling it into the upstream.
