### PR TITLE
Typo in documentation ("_exit_code" => "_ok_code")

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -241,7 +241,7 @@ exits with 0, 3, or 5 exit code.
 
 .. note::
 
-	If you use ``_exit_code``, you must specify **all** the exit codes that are
+	If you use ``_ok_code``, you must specify **all** the exit codes that are
 	considered "ok", like (typically) 0.
 	
 	


### PR DESCRIPTION
referred to argument as `_exit_code` instead of `_ok_code`
