### PR TITLE
fix sub-commands for python reserved words

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -466,9 +466,11 @@ class Command(object):
     def __getattribute__(self, name):
         # convenience
         getattr = partial(object.__getattribute__, self)
-        
-        if name.startswith("_"): return getattr(name)    
-        if name == "bake": return getattr("bake")         
+
+        if name.startswith("_"): return getattr(name)
+        if name == "bake": return getattr("bake")
+        if name.endswith("_"):
+            name = name[:-1]
         return getattr("bake")(name)
 
     


### PR DESCRIPTION
with this workaround it is possible to use reserved python words as subcommands

``` python
import sh
sh.dab.exec_.ls('-l')
#executed /sbin/dab exec ls -l
```
