### PR TITLE
Added custom separator for long keyword args.

### DIFF
--- a/test.py
+++ b/test.py
@@ -407,7 +407,17 @@ else:
         
         self.assertEqual(python(py.name, long_option="hyphen").strip(), "HYPHEN")
 
-    
+    def test_custom_separator(self):
+        py = create_tmp_test("""
+import sys
+print sys.argv[1]
+""")
+        self.assertEqual(python(py.name, 
+            {"long-option": "underscore"}, _sep="=custom=").strip(), "--long-option=custom=underscore")
+        # test baking too
+        python_baked = python.bake(py.name, {"long-option": "underscore"}, _sep="=baked=")
+        self.assertEqual(python_baked().strip(), "--long-option=baked=underscore")
+        
     def test_command_wrapper(self):
         from sh import Command, which
         


### PR DESCRIPTION
Hi Andrew,

I added a _sep special keyword to sh calls to allow for a custom separator for long form arguments instead of forcing it to be "="; there are quite a few programs which do not respect the --long-option=value format. Here is an example:
http://vcftools.sourceforge.net/options.html
