### PR TITLE
Make the starting process message info

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -283,7 +283,7 @@ class RunningCommand(object):
         
         
         if spawn_process:
-            self.log.debug("starting process")
+            self.log.info("starting process")
             self.process = OProc(cmd, stdin, stdout, stderr, 
                 self.call_args, pipe=pipe)
             


### PR DESCRIPTION
When consuming sh in a program, I want to have a verbose setting in
my program that will print what shell commands the program is executing,
but not necessarily the full trace of how that execution is happening.
Putting just the starting command message up to the info level allows it
to still not print by default, and still to print at the debug level.
