### PR TITLE
Sane exclusions for MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 include AUTHORS.md LICENSE.txt README.md test.py
+
+global-exclude *.pyc
+global-exclude .gitignore
+global-exclude .DS_Store


### PR DESCRIPTION
MANIFEST.in can also inform python which files should not be included
in any packaged version of sh.
