### PR TITLE
Attach return_code to ErrorReturnCode

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -153,6 +153,8 @@ def get_rc_exc(rc):
         name = "SignalException_%d" % abs(rc)
         exc = type(name, (SignalException,), {})
         
+    exc.return_code = int(rc)
+
     rc_exc_cache[rc] = exc
     return exc
 

--- a/test.py
+++ b/test.py
@@ -73,6 +73,15 @@ print(args[0])
         from sh import ls, ErrorReturnCode
         self.assertEqual(ls("/").exit_code, 0)
         self.assertRaises(ErrorReturnCode, ls, "/aofwje/garogjao4a/eoan3on")
+
+    def test_exit_code_return_code(self):
+        from sh import ls, ErrorReturnCode
+        self.assertRaises(ErrorReturnCode, ls, "/aofwje/garogjao4a/eoan3on")
+
+        try:
+            ls("/aofwje/garogjao4a/eoan3on")
+        except Exception as exception:
+            self.assertEqual(exception.return_code, 2)
         
     def test_glob_warning(self):
         from sh import ls


### PR DESCRIPTION
All exceptions should have an integer return code available on the
exception object. Otherwise, users must parse the name of the exception
class to retrieve this data.
