### PR TITLE
tox.ini: Add "cover" target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = py26, py27, py32, py33, cover
+
+[testenv]
+commands = python test.py
+deps = nose
+
+[testenv:cover]
+basepython = python2.6
+commands =
+    coverage erase
+    coverage run --source sh test.py
+    coverage report
+    coverage xml
+    coverage html
+deps =
+    {[testenv]deps}
+    coverage
+
+# we separate coverage into its own testenv because a) "last run wins" wrt
+# cobertura jenkins reporting and b) pypy and jython can't handle any
+# combination of versions of coverage and nosexcover that i can find.
+


### PR DESCRIPTION
```
(py26.venv)marca@marca-mac:~/dev/git-repos/sh$ tox
...
cover runtests: commands[2] | coverage report
Name    Stmts   Miss  Cover
---------------------------
sh        916    142    84%
cover runtests: commands[3] | coverage xml
cover runtests: commands[4] | coverage html
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  cover: commands succeeded
  congratulations :)
```
