### PR TITLE
Added info logging call to log exactly what command will be started. Had...

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -323,6 +323,7 @@ class RunningCommand(object):
 
         if spawn_process:
             self.log.debug("starting process")
+            Logger("command", "starting command").info(" ".join(cmd))
             self.process = OProc(cmd, stdin, stdout, stderr,
                 self.call_args, pipe=pipe)
 


### PR DESCRIPTION
I wanted the ability to log just the command string on the info level, without the extra debug info. Example:

(line 86 logging_enabled must be True)

import sh, logging
logging.basicConfig(level=logging.INFO)
sh.ls("-lah")

> INFO:command:starting command: /bin/ls -lah
