### PR TITLE
remove extra judge

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1717,7 +1717,6 @@ class SelfWrapper(ModuleType):
         ModuleType.__setattr__(self, name, value)
 
     def __getattr__(self, name):
-        if name == "env": raise AttributeError
         return self.env[name]
 
     # accept special keywords argument to define defaults for all operations


### PR DESCRIPTION
already have SelfWrapper.env, so it it impossible to reach getattr if name == "env"
