### PR TITLE
sh.py should not try to execute a folder

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -192,7 +192,9 @@ def get_rc_exc(rc):
 
 def which(program):
     def is_exe(fpath):
-        return os.path.exists(fpath) and os.access(fpath, os.X_OK)
+        return (os.path.exists(fpath) and
+                os.access(fpath, os.X_OK) and
+                os.path.isfile(os.path.realpath(fpath)))
 
     fpath, fname = os.path.split(program)
     if fpath:

--- a/test.py
+++ b/test.py
@@ -329,6 +329,35 @@ print(sh.HERP + " " + str(len(os.environ)))
 
         self.assertEqual(Command(which("ls")), ls)
 
+    def test_doesnt_execute_directories(self):
+        import tempfile
+        save_path = os.environ['PATH']
+        bin_dir1 = tempfile.mkdtemp()
+        bin_dir2 = tempfile.mkdtemp()
+        gcc_dir1 = os.path.join(bin_dir1, 'gcc')
+        gcc_file2 = os.path.join(bin_dir2, 'gcc')
+        try:
+            os.environ['PATH'] = os.pathsep.join((bin_dir1, bin_dir2))
+            # a folder named 'gcc', its executable, but should not be
+            # discovered by internal which(1)-clone
+            os.makedirs(gcc_dir1)
+            # an executable named gcc -- only this should be executed
+            bunk_header = u'#!/bin/sh\necho $*'.encode('ascii')
+            open(gcc_file2, 'w').write(bunk_header)
+            os.chmod(gcc_file2, 0755)
+            from sh import gcc
+            self.assertEqual(gcc._path, gcc_file2)
+            self.assertEqual(gcc('no-error').stdout.strip(), u'no-error')
+        finally:
+            os.environ['PATH'] = save_path
+            if os.path.exists(gcc_file2):
+                os.unlink(gcc_file2)
+            if os.path.exists(gcc_dir1):
+                os.rmdir(gcc_dir1)
+            if os.path.exists(bin_dir1):
+                os.rmdir(bin_dir1)
+            if os.path.exists(bin_dir1):
+                os.rmdir(bin_dir2)
 
     def test_multiple_args_short_option(self):
         py = create_tmp_test("""


### PR DESCRIPTION
Problem: sh attempts to execute folders because which(1) fails
         to determine that although folders may have execute-bit
         set, they are not executable by execv(3)-family calls

Symptom: such call is blocking, never returns (!)

Solution: check the target is a file (following symlinks).

Details: The internal which(1) clone will attempt to execute any
         folder matching the Command issued. So, given the PATH of:

```
          /usr/opt/bin/gcc   <- directory
          /usr/bin/gcc       <- executable file

     sh would attempt to execute the folder, /usr/opt/bin/gcc.
```

[ As executing a folder would cause sh to block indefinitely
  (an unhandled OSError is thrown on exec), the test adds a ._path
  value assertion first, which prevents this test from hanging when
  the fix is un-applied.  ]
