### PR TITLE
Only trap sighup when the process is "backgrounded"

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -836,7 +836,7 @@ class OProc(object):
             # ignoring SIGHUP lets us persist even after the parent process
             # exits
             # only ignore if we're backgrounded
-            if self.call_args["bg"] is False:
+            if self.call_args["bg"] is True:
                 signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
             # this piece of ugliness is due to a bug where we can lose output


### PR DESCRIPTION
First step in working on the suggestion in https://github.com/amoffat/sh/issues/158.  It looks like this fails to terminate the children in my case.  I'm guessing that OProc.output_thread is still active in my case, I need to test that, but in the mean time I'd like to make sure that this approach will be useful.
