### PR TITLE
Update SIGNALS_THAT_SHOULD_THROW_EXCEPTION tuple

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -156,11 +156,17 @@ class ErrorReturnCode(Exception):
 class SignalException(ErrorReturnCode): pass
 
 SIGNALS_THAT_SHOULD_THROW_EXCEPTION = (
+    signal.SIGABRT,
+    signal.SIGBUS,
+    signal.SIGFPE,
+    signal.SIGILL,
+    signal.SIGINT,
     signal.SIGKILL,
+    signal.SIGPIPE,
+    signal.SIGQUIT,
     signal.SIGSEGV,
     signal.SIGTERM,
-    signal.SIGINT,
-    signal.SIGQUIT
+    signal.SIGSYS,
 )
 
 


### PR DESCRIPTION
I have been using `sh` as a part of a larger integration test infrastructure for a `c++` project. Sometimes the commands I execute just terminate unexpectedly (i.e., the `SIGABRT` signal is issued). I am proposing to extend the list of signals that should throw an exception to include several common signals that are indicative of bad things happening under the hood :wink: 

The list was updated using as reference the table reported in [this Wikipedia article](http://en.wikipedia.org/wiki/Unix_signal).
