### PR TITLE
Add a pushd context

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1584,6 +1584,17 @@ class StreamBufferer(object):
 
 
 
+class pushd(object):
+    def __init__(self, path):
+        self.path = path
+
+    def __enter__(self):
+        self.cwd = os.getcwd()
+        os.chdir(self.path)
+
+    def __exit__(self, exception_type, exception_val, trace):
+        os.chdir(self.cwd)
+
 
 
 # this allows lookups to names that aren't found in the global scope to be


### PR DESCRIPTION
I find that I write this little boilerplate all the time and I think
other sh users would find it useful as well. This simply creates a
context to run commands in another directory and ensures that the
original working directory will be returned to.

Usage:

``` python
from sh import pushd, pwd

pwd()
with pushd('/tmp'):
    pwd()
pwd()
```
