### PR TITLE
Include original path in CommandNotFound.

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -547,10 +547,10 @@ class Command(object):
 
 
     def __init__(self, path):
-        path = which(path)
-        if not path:
+        found = which(path)
+        if not found:
             raise CommandNotFound(path)
-        self._path = path
+        self._path = found
 
         self._partial = False
         self._partial_baked_args = []


### PR DESCRIPTION
Whenever `which()` fails to resolve the path it returns `None` and
overwrites the original `path` value. Later when we create 
`CommandNotFound` exception we always pass `None` instead of the
original `path` value and it makes `CommandNotFound` not so usefull.
