### PR TITLE
ok_code now accepts python3 range and anything that has a __contains__ m...

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -727,7 +727,7 @@ If you're using glob.glob(), please use sh.glob() instead." % self._path, stackl
         tmp_call_args, kwargs = self._extract_call_args(kwargs, self._partial_call_args)
         call_args.update(tmp_call_args)
 
-        if not isinstance(call_args["ok_code"], (tuple, list)):
+        if not getattr(call_args["ok_code"], '__contains__', None):
             call_args["ok_code"] = [call_args["ok_code"]]
 
 

--- a/test.py
+++ b/test.py
@@ -130,6 +130,7 @@ exit(3)
 
         ls("/aofwje/garogjao4a/eoan3on", _ok_code=code_to_pass)
         ls("/aofwje/garogjao4a/eoan3on", _ok_code=[code_to_pass])
+        ls("/aofwje/garogjao4a/eoan3on", _ok_code=range(code_to_pass + 1))
 
     def test_quote_escaping(self):
         py = create_tmp_test("""


### PR DESCRIPTION
I'd like to use range in python 3.4 to specify ok_code. For example: `_ok_code=range(128)`
