### PR TITLE
fix args with context to clean up after an exception is thrown

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2138,8 +2138,10 @@ def args(*args, **kwargs):
         key = key.lstrip("_")
         call_args[key] = value
 
-    yield
-    call_args.update(old_args)
+    try:
+        yield
+    finally:
+        call_args.update(old_args)
 
 
 

--- a/test.py
+++ b/test.py
@@ -1590,12 +1590,12 @@ for i in range(5):
     def test_pushd(self):
         """ test that pushd is just a specialized form of sh.args """
         import os
-        old_wd = os.getcwd()
+        old_wd = sh.pwd().strip()
         with sh.pushd(tempdir):
             new_wd = sh.pwd().strip()
 
         self.assertNotEqual(old_wd, tempdir)
-        self.assertEqual(old_wd, os.getcwd())
+        self.assertEqual(old_wd, sh.pwd().strip())
         self.assertEqual(new_wd, tempdir)
 
 
@@ -1604,14 +1604,30 @@ for i in range(5):
         command settings """
         import os
 
-        old_wd = os.getcwd()
+        old_wd = sh.pwd().strip()
         with sh.args(_cwd=tempdir):
             new_wd = sh.pwd().strip()
 
         # sanity
         self.assertNotEqual(old_wd, tempdir)
-        self.assertEqual(old_wd, os.getcwd())
+        self.assertEqual(old_wd, sh.pwd().strip())
         self.assertEqual(new_wd, tempdir)
+
+
+    def test_args_context_exception(self):
+        """ test that args with-context will revert command settings
+        if an exception is thrown """
+        import os
+
+        old_wd = os.getcwd()
+        try:
+            with sh.args(_cwd=tempdir):
+                new_wd = sh.pwd().strip()
+                raise Exception()
+        except Exception:
+            self.assertNotEqual(old_wd, tempdir)
+            self.assertEqual(old_wd, sh.pwd().strip())
+            self.assertEqual(new_wd, tempdir)
 
 
     def test_piped_direct(self):


### PR DESCRIPTION
As a related question, it looks like with contexts are deprecated, since they're not threadsafe. What would be a replacement for pushd?