### PR TITLE
Ignore all python-compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-*.pyc
+__pycache__/
+*.py[co]


### PR DESCRIPTION
If i am not mistaken, python 3 generate its `pyc` files in a `__pycache__` directory.
The `.pyo` files are similar to `pyc` (with optimisation).
I haven't included `pyd` files since they are windows-only.