### PR TITLE
Kill the entire process group when a command  times out

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1531,7 +1531,9 @@ class OProc(object):
     def signal(self, sig):
         self.log.debug("sending signal %d", sig)
         try:
-            os.kill(self.pid, sig)
+            # Kill the entire process group as the command may have
+            # spawned subprocesses we don't want left around
+            os.killpg(os.getpgid(self.pid), sig)
         except OSError:
             pass
 


### PR DESCRIPTION
In cases where the command being executed spawns subcommands
we need to ensure they are all killed, so that the timeout
occurs when it should instead of waiting for the subprocesses to exit.

The problem I'm trying the fix can be reproduced by setting a timeout on a git clone, git calls subprocesses which prevent the timeout from working. Killing the process group should be safe because os.setsid() was called earlier so the commands have been started in their own group.