### PR TITLE
Minor update to sh.Command documentation

### DIFF
--- a/_docs_sources/index.rst
+++ b/_docs_sources/index.rst
@@ -79,12 +79,14 @@ substitute the dash for an underscore::
 
     For commands with more exotic characters in their names, like ``.``, or
     if you just don't like the "magic"-ness of dynamic lookups, you
-    may use sh's ``Command`` wrapper and pass in the absolute path of the
-    executable::
+    may use sh's ``Command`` wrapper and pass in the command name or 
+    the absolute path of the executable::
 	
 		import sh
-		run = sh.Command("/home/amoffat/run.sh")
+		run = sh.Command("/home/amoffat/run.sh") # Absolute path
 		run()
+		lscmd = sh.Command("ls")  # Absolute path not needed
+		lscmd()
 
 
 Multiple arguments


### PR DESCRIPTION
Specified that absolute path may not be always required. Added an example.
Fixes #209