### PR TITLE
Proper behavior with long_sep=' '

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -857,8 +857,13 @@ output"),
                 elif v is False:
                     pass
                 else:
-                    arg = encode_to_py3bytes_or_py2str("--%s%s%s" % (k, sep, v))
-                    processed.append(arg)
+                    # pass long args separated by space as two args
+                    if sep != ' ':
+                        arg = encode_to_py3bytes_or_py2str("--%s%s%s" % (k, sep, v))
+                        processed.append(arg)
+                    else:
+                        processed.append(encode_to_py3bytes_or_py2str('--' + k))
+                        processed.append(encode_to_py3bytes_or_py2str(v))
         return processed
 
 


### PR DESCRIPTION
I was automating some `virt-builder` stuff with `sh`, and `virt-builder` doesn't seem to properly handle long arguments. Specifically, it requires the flag and the value to be separate arguments. As it was, `sh` didn't separate these out properly, and this happened:

```
  STDERR:
/usr/bin/virt-builder: unknown option `--output o/1.img'.
virt-builder: build virtual machine images quickly
```

This pull requests implements argument separation for long arguments with `_long_sep=' '`. The `--flag` and the `value` are simply added as separate arguments.