### PR TITLE
Add '_cmd_cls' special keyword for passing a RunningCommand subclass

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -667,6 +667,9 @@ class Command(object):
     _prepend_stack = []
 
     _call_args = {
+        # running command (sub)class
+        "cmd_cls": RunningCommand,
+
         # currently unsupported
         #"fg": False, # run command in foreground
 
@@ -1017,8 +1020,9 @@ If you're using glob.glob(), please use sh.glob() instead." % self._path, stackl
         if output_redirect_is_filename(stderr):
             stderr = open(str(stderr), "wb")
 
+        running_cmd_cls = call_args["cmd_cls"]
 
-        return RunningCommand(cmd, call_args, stdin, stdout, stderr)
+        return running_cmd_cls(cmd, call_args, stdin, stdout, stderr)
 
 
 
@@ -2159,6 +2163,7 @@ class Environment(dict):
     # "import time" may override the time system program
     whitelist = set([
         "Command",
+        "RunningCommand",
         "CommandNotFound",
         "DEFAULT_ENCODING",
         "DoneReadingForever",

--- a/test.py
+++ b/test.py
@@ -555,8 +555,8 @@ print(sys.argv[1])
                 else:
                     self.foo_ex = None
                 finally:
-                    self.foo_stdout = 'foo' in self.stdout
-                    self.foo_stderr = 'foo' in self.stderr
+                    self.foo_stdout = b"foo" in self.stdout
+                    self.foo_stderr = b"foo" in self.stderr
 
         py = create_tmp_test("""
 import sys


### PR DESCRIPTION
Sometimes it's necessary to customize how a command is run in a way that:
(a) it is not supported by any existing special keyword arguments and
(b) it doesn't make sense to add a new special keyword to `sh` for it because it is very specific to the particular use case. 

This PR introduces a new special keyword, `_cmd_cls` (feel free to pick a better name), that allows the client to pass a custom `RunningCommand` subclass. This opens up new possibilities that aren't currently possible (at least not without monkeypatching `sh.RunningCommand`).
