### PR TITLE
Allows baking subclasses of commands into instances of the subclass

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -886,7 +886,7 @@ If you're using glob.glob(), please use sh.glob() instead." % self._path, stackl
 
     # TODO needs documentation
     def bake(self, *args, **kwargs):
-        fn = Command(self._path)
+        fn = type(self)(self._path)
         fn._partial = True
 
         call_args, kwargs = self._extract_call_args(kwargs)


### PR DESCRIPTION
I subclassed ``sh.Command`` to finally add command monitoring as initially mentioned in amoffat/sh#138, and need this for my subclass to survive baking !