### PR TITLE
Automatically handle failures in producers of pipe output

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -479,7 +479,18 @@ class RunningCommand(object):
         # process, and that's if we're using a with-context with our command
         if spawn_process:
             self.log.info("starting process")
-            self.process = OProc(self.log, cmd, stdin, stdout, stderr,
+            if isinstance(stdin, RunningCommand):
+                self.stdin_proc = stdin
+
+                if stdin.call_args["piped"] == "direct":
+                    oproc_stdin = stdin.process
+                else:
+                    oproc_stdin = stdin.process._pipe_queue
+            else:
+                self.stdin_proc = None
+                oproc_stdin = stdin
+
+            self.process = OProc(self.log, cmd, oproc_stdin, stdout, stderr,
                     self.call_args, pipe)
 
             if should_wait:
@@ -491,6 +502,9 @@ class RunningCommand(object):
             self._process_completed = True
 
             exit_code = self.process.wait()
+            if self.stdin_proc is not None:
+                stdin_proc_exit_code = self.stdin_proc.process.wait()
+
             if self.process.timed_out:
                 # if we timed out, our exit code represents a signal, which is
                 # negative, so let's make it positive to store in our
@@ -498,6 +512,9 @@ class RunningCommand(object):
                 raise TimeoutException(-exit_code)
             else:
                 self.handle_command_exit_code(exit_code)
+
+            if self.stdin_proc is not None:
+                self.stdin_proc.handle_command_exit_code(stdin_proc_exit_code)
 
             # https://github.com/amoffat/sh/issues/185
             if self.call_args["done"]:
@@ -989,11 +1006,7 @@ If you're using glob.glob(), please use sh.glob() instead." % self._path, stackl
                 if first_arg.call_args["bg"]:
                     call_args["bg"] = True
 
-                if first_arg.call_args["piped"] == "direct":
-                    stdin = first_arg.process
-                else:
-                    stdin = first_arg.process._pipe_queue
-
+                stdin = first_arg
             else:
                 args.insert(0, first_arg)
 

--- a/sh.py
+++ b/sh.py
@@ -503,7 +503,7 @@ class RunningCommand(object):
 
             exit_code = self.process.wait()
             if self.stdin_proc is not None:
-                stdin_proc_exit_code = self.stdin_proc.process.wait()
+                self.stdin_proc.wait()
 
             if self.process.timed_out:
                 # if we timed out, our exit code represents a signal, which is
@@ -512,9 +512,6 @@ class RunningCommand(object):
                 raise TimeoutException(-exit_code)
             else:
                 self.handle_command_exit_code(exit_code)
-
-            if self.stdin_proc is not None:
-                self.stdin_proc.handle_command_exit_code(stdin_proc_exit_code)
 
             # https://github.com/amoffat/sh/issues/185
             if self.call_args["done"]:

--- a/test.py
+++ b/test.py
@@ -1856,10 +1856,29 @@ for i in range(10):
         out = python(py.name, _out=log_line)
         self.assertEqual(output, [("hello", i) for i in range(10)])
 
+    def test_unchecked_producer_failure(self):
+        from sh import ErrorReturnCode_2
 
+        producer = create_tmp_test("""
+import sys
+for i in range(10):
+    print(i)
+sys.exit(2)
+""")
 
+        consumer = create_tmp_test("""
+import sys
+for line in sys.stdin:
+    pass
+""")
 
+        direct_pipe = python(producer.name, _piped="direct")
 
+        self.assertRaises(ErrorReturnCode_2, python, direct_pipe, consumer.name)
+
+        normal_pipe = python(producer.name, _piped="direct")
+
+        self.assertRaises(ErrorReturnCode_2, python, normal_pipe, consumer.name)
 
 
 

--- a/test.py
+++ b/test.py
@@ -1880,6 +1880,38 @@ for line in sys.stdin:
 
         self.assertRaises(ErrorReturnCode_2, python, normal_pipe, consumer.name)
 
+    def test_unchecked_pipeline_failure(self):
+        # similar to test_unchecked_producer_failure, but this
+        # tests a multi-stage pipeline
+
+        from sh import ErrorReturnCode_2
+
+        producer = create_tmp_test("""
+import sys
+for i in range(10):
+    print(i)
+sys.exit(2)
+""")
+
+        middleman = create_tmp_test("""
+import sys
+for line in sys.stdin:
+    print("> " + line)
+""")
+
+        consumer = create_tmp_test("""
+import sys
+for line in sys.stdin:
+    pass
+""")
+
+        producer_direct_pipe = python(producer.name, _piped="direct")
+        middleman_direct_pipe = python(producer_direct_pipe, middleman.name, _piped="direct")
+        self.assertRaises(ErrorReturnCode_2, python, middleman_direct_pipe, consumer.name)
+
+        producer_normal_pipe = python(producer.name, _piped=True)
+        middleman_normal_pipe = python(producer_normal_pipe, middleman.name, _piped=True)
+        self.assertRaises(ErrorReturnCode_2, python, middleman_normal_pipe, consumer.name)
 
 
 class MiscTests(unittest.TestCase):


### PR DESCRIPTION
`sh` does not currently raise an exception when the producer side of a pipeline exits with an erroneous exit code unless you explicitly check for it.  This adds tests and fixes.