### PR TITLE
DOC: Badge fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/amoffat/sh.svg?branch=master)](https://travis-ci.org/amoffat/sh) [![Coverage Status](https://coveralls.io/repos/amoffat/sh/badge.svg?branch=master&service=github)](https://coveralls.io/github/amoffat/sh?branch=master)
 
-[![Version](https://pypip.in/v/sh/badge.png)](https://pypi.python.org/pypi/sh) [![Downloads](https://pypip.in/d/sh/badge.png)](https://pypi.python.org/pypi/sh)
+[![Version](https://img.shields.io/pypi/v/sh.svg)](https://pypi.python.org/pypi/sh) [![Downloads](https://img.shields.io/pypi/dd/sh.svg)](https://pypi.python.org/pypi/sh)
 
 sh (previously [pbs](http://pypi.python.org/pypi/pbs)) is a full-fledged
 subprocess replacement for Python 2.6 - 3.4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/amoffat/sh.svg?branch=master)](https://travis-ci.org/amoffat/sh) [![Coverage Status](https://coveralls.io/repos/amoffat/sh/badge.png?branch=master)](https://coveralls.io/r/amoffat/sh?branch=master)
+[![Build Status](https://travis-ci.org/amoffat/sh.svg?branch=master)](https://travis-ci.org/amoffat/sh) [![Coverage Status](https://coveralls.io/repos/amoffat/sh/badge.svg?branch=master)](https://coveralls.io/r/amoffat/sh?branch=master)
 
 [![Version](https://pypip.in/v/sh/badge.png)](https://pypi.python.org/pypi/sh) [![Downloads](https://pypip.in/d/sh/badge.png)](https://pypi.python.org/pypi/sh)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/amoffat/sh.svg?branch=master)](https://travis-ci.org/amoffat/sh) [![Coverage Status](https://coveralls.io/repos/amoffat/sh/badge.svg?branch=master)](https://coveralls.io/r/amoffat/sh?branch=master)
+[![Build Status](https://travis-ci.org/amoffat/sh.svg?branch=master)](https://travis-ci.org/amoffat/sh) [![Coverage Status](https://coveralls.io/repos/amoffat/sh/badge.svg?branch=master&service=github)](https://coveralls.io/github/amoffat/sh?branch=master)
 
 [![Version](https://pypip.in/v/sh/badge.png)](https://pypi.python.org/pypi/sh) [![Downloads](https://pypip.in/d/sh/badge.png)](https://pypi.python.org/pypi/sh)
 


### PR DESCRIPTION
* Use SVG badges.
* Update coveralls link format.
* Switch from pypip.in to shields.io as pypip.in is down ( https://github.com/badges/pypipins/issues/39 ).