### PR TITLE
cd allows no arguments to move to the home directory

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2237,8 +2237,11 @@ Please import sh or import programs individually.")
     # common shell builtins that people are used to, but which aren't actually
     # full-fledged system binaries
 
-    def b_cd(self, path):
-        os.chdir(path)
+    def b_cd(self, path=None):
+        if path:
+            os.chdir(path)
+        else:
+            os.chdir(os.path.expanduser('~'))
 
     def b_which(self, program):
         return which(program)


### PR DESCRIPTION
```
>>> sh.cd('test')
>>> sh.pwd()
/home/user/test
>>> sh.cd()
>>> sh.pwd()
/home/user
```