### PR TITLE
Support for user-defined long argument prefix

### DIFF
--- a/test.py
+++ b/test.py
@@ -530,6 +530,18 @@ print(sys.argv[1])
         python_baked = python.bake(py.name, {"long-option": "underscore"}, _long_sep="=baked=")
         self.assertEqual(python_baked().strip(), "--long-option=baked=underscore")
 
+    def test_custom_long_prefix(self):
+        py = create_tmp_test("""
+import sys
+print(sys.argv[1])
+""")
+        self.assertEqual(python(py.name,
+            {"long-option": "underscore"}, _long_prefix="-custom-").strip(), "-custom-long-option=underscore")
+        # test baking too
+        python_baked = python.bake(py.name, {"long-option": "underscore"}, _long_prefix="-baked-")
+        self.assertEqual(python_baked().strip(), "-baked-long-option=underscore")
+
+
     def test_command_wrapper(self):
         from sh import Command, which
 


### PR DESCRIPTION
Some programs use prefixes other than -- to identify long arguments. Example:
packer. This adds support for parameter _long_prefix that can be used to define
the prefix for long arguments.