### PR TITLE
Actually change directory in pushd context

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -28,7 +28,6 @@ __version__ = "1.11"
 __project_url__ = "https://github.com/amoffat/sh"
 
 
-
 import platform
 
 if "windows" in platform.system().lower():
@@ -2121,10 +2120,13 @@ class StreamBufferer(object):
 
 @contextmanager
 def pushd(path):
-    """ pushd is just a specialized form of args, where we're passing in the
-    current working directory """
-    with args(_cwd=path):
-        yield
+    """ pushd changes the actual working directory for the duration of the
+    context, unlike the _cwd arg this will work with other built-ins such as
+    sh.glob correctly """
+    orig_path = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(orig_path)
 
 
 @contextmanager

--- a/test.py
+++ b/test.py
@@ -1588,7 +1588,7 @@ for i in range(5):
 
 
     def test_pushd(self):
-        """ test that pushd is just a specialized form of sh.args """
+        """ test basic pushd functionality """
         import os
         old_wd = os.getcwd()
         with sh.pushd(tempdir):
@@ -1597,6 +1597,48 @@ for i in range(5):
         self.assertNotEqual(old_wd, tempdir)
         self.assertEqual(old_wd, os.getcwd())
         self.assertEqual(new_wd, tempdir)
+
+
+    def test_pushd_glob(self):
+        """ test that pushd works with glob correctly """
+        import sh
+        from sh import mkdir, rm, touch, ls
+
+        child = join(tempdir, 'glob_test_dir')
+        mkdir('-p', child)
+
+        touch(join(tempdir, 'glob-test-root'))
+        touch(join(child, 'glob-test-child'))
+
+        old_wd = os.getcwd()
+        try:
+            os.chdir(tempdir)
+            self.assertEqual('glob-test-root', ls(sh.glob('glob-test-*')).strip())
+
+            with sh.pushd('glob_test_dir'):
+                self.assertEqual('glob-test-child', ls(sh.glob('glob-test-*')).strip())
+
+            self.assertEqual('glob-test-root', ls(sh.glob('glob-test-*')).strip())
+        finally:
+            rm('-r', '-f', 'glob_test_dir')
+            rm('-f', 'glob-test-root')
+            os.chdir(old_wd)
+
+
+    def test_pushd_cd(self):
+        """ test that pushd works like pushd/popd with built-in cd correctly """
+        import sh
+        from sh import mkdir
+
+        child = join(tempdir, 'pushd_cd_test_dir')
+        mkdir('-p', child)
+
+        old_wd = os.getcwd()
+        with sh.pushd(tempdir):
+            self.assertEqual(tempdir, os.getcwd())
+            sh.cd(child)
+            self.assertEqual(child, os.getcwd())
+        self.assertEqual(old_wd, os.getcwd())
 
 
     def test_args_context(self):


### PR DESCRIPTION
The pushd context needs to actually change the directory instead of just
setting the _cwd argument. If it doesn't it leads to unexpected behavoir
such as `sh.glob` and `os.getcwd` not working correctly inside of the
pushd context.

This also changes pushd to restore the directory the user was in when
exiting the context, even if the user cd's while inside of the context.
This mirror's bash's pushd/popd behavoir.