### PR TITLE
Support univeral wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ env:
     - LC_ALL=C
     - LC_ALL=en_US.UTF-8
 
-before_script: pip install coverage coveralls
+before_script:
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install 'coverage<4'; fi
+    - pip install coverage coveralls
 
 script:
     - coverage run --source sh test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@ import os
 import sys
 import sh
 
-try: from distutils.core import setup
-except ImportError: from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 setup(


### PR DESCRIPTION
sh already supports both py2/py3 from the same code base, so there's no
reason not to produce a universal wheel.

We need to try and import setuptools first (so we can even build wheels
in the first place) and fallback to distutils only if we don't have
setuptools.  (We should prefer setuptools anyways:
https://python-packaging-user-guide.readthedocs.io/en/latest/current/)
