### PR TITLE
Remove check for binary data

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2031,15 +2031,6 @@ class StreamBufferer(object):
         self._buffering_lock.acquire()
         self.log.debug("got buffering lock to process chunk (buffering: %d)", self.type)
         try:
-            # we've encountered binary, permanently switch to N size buffering
-            # since matching on newline doesn't make sense anymore
-            if self.type == 1:
-                try:
-                    chunk.decode(self.encoding, self.decode_errors)
-                except:
-                    self.log.debug("detected binary data, changing buffering")
-                    self.change_buffering(1024)
-
             # unbuffered
             if self.type == 0:
                 if self._use_up_buffer_first:


### PR DESCRIPTION
There's no cheap way we can distinguish between binary data and multibyte strings. It is perfectly valid for `decode()` to fail since the chunk may be incomplete because of buffering. For example, `'ø'` is `b'\xc3\xb8'` in utf-8, but we could receive the string in two chunks, `b'\xc3'` and `b'\xb8'`, that each don't decode.

Simply remove the check and trust the user to set the correct `out_bufsize`. If a fully assembled multibyte line still won't decode, `next()` will handle it and return binary data.