### PR TITLE
Fix memory leak when running commands

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1786,6 +1786,7 @@ class OProc(object):
             os.close(session_pipe_write)
             sid, pgid = os.read(session_pipe_read,
                     1024).decode(DEFAULT_ENCODING).split(",")
+            os.close(session_pipe_read)
             self.sid = int(sid)
             self.pgid = int(pgid)
 

--- a/test.py
+++ b/test.py
@@ -2545,6 +2545,7 @@ print("cool")
         def get_num_fds():
             lines = sh.lsof(p=test_pid).strip().split("\n")
             def test(line):
+                line = line.upper()
                 return "CHR" in line or "PIPE" in line
 
             lines = [line for line in lines if test(line)]


### PR DESCRIPTION
In commit dd571459719473a00c143eb37b7661207c5ff9ef the file descriptor
closure of session_pipe_read was accidentally removed, causing a leak.

The test at least on Linux didn't detect this because the lsof output
prints "pipe" in lower-case, instead of upper case, as expected by the
test. Therefore the fd leak test didn't account for the leaked
descriptors.