### PR TITLE
don't actually raise a DeprecationWarning

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -104,6 +104,7 @@ import resource
 from collections import deque
 import logging
 import weakref
+import warnings
 
 
 # a re-entrant lock for pushd.  this way, multiple threads that happen to use
@@ -2827,7 +2828,7 @@ def args(**kwargs):
 
     kwargs_str = ",".join(["%s=%r" % (k,v) for k,v in kwargs.items()])
 
-    raise DeprecationWarning("""
+    warnings.warn("""
 
 sh.args() has been deprecated because it was never thread safe.  use the
 following instead:
@@ -2841,7 +2842,7 @@ or
     from sh2 import your_command
     your_command()
 
-""".format(kwargs=kwargs_str))
+""".format(kwargs=kwargs_str), DeprecationWarning)
 
 
 


### PR DESCRIPTION
If you raise the DeprecationWarning then it acts as an actual exception.