### PR TITLE
Make glob patch support `recursive` argument in Python 3.5

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -375,8 +375,8 @@ class GlobResults(list):
         self.path = path
         list.__init__(self, results)
 
-def glob(path):
-    expanded = GlobResults(path, _old_glob(path))
+def glob(path, *args, **kwargs):
+    expanded = GlobResults(path, _old_glob(path, *args, **kwargs))
     return expanded
 
 glob_module.glob = glob

--- a/test.py
+++ b/test.py
@@ -266,6 +266,17 @@ print(sys.argv[1:])
         out = python(py.name, files).strip()
         self.assertEqual(out, "['*.faowjefoajweofj']")
 
+    def test_patched_glob_with_recursive_argument(self):
+        if IS_PY3 and MINOR_VER >= 5:
+            from glob import glob
+
+            py = create_tmp_test("""
+import sys
+print(sys.argv[1:])
+""")
+            files = glob("*.faowjefoajweofj", recursive=True)
+            out = python(py.name, files).strip()
+        self.assertEqual(out, "['*.faowjefoajweofj']")
 
     def test_exit_code_with_hasattr(self):
         from sh import ErrorReturnCode

--- a/test.py
+++ b/test.py
@@ -135,6 +135,7 @@ requires_posix = skipUnless(os.name == "posix", "Requires POSIX")
 requires_utf8 = skipUnless(sh.DEFAULT_ENCODING == "UTF-8", "System encoding must be UTF-8")
 not_osx = skipUnless(not IS_OSX, "Doesn't work on OSX")
 requires_py3 = skipUnless(IS_PY3, "Test only works on Python 3")
+requires_py35 = skipUnless(IS_PY3 and MINOR_VER >= 5, "Test only works on Python 3.5 or higher")
 
 
 def create_tmp_test(code, prefix="tmp", delete=True, **kwargs):
@@ -266,7 +267,7 @@ print(sys.argv[1:])
         out = python(py.name, files).strip()
         self.assertEqual(out, "['*.faowjefoajweofj']")
 
-    @unittest.skipUnless(IS_PY3 and MINOR_VER >= 5, "only applicable to Python 3.5 or higher")
+    @requires_py35
     def test_patched_glob_with_recursive_argument(self):
         from glob import glob
 

--- a/test.py
+++ b/test.py
@@ -276,7 +276,7 @@ print(sys.argv[1:])
 """)
             files = glob("*.faowjefoajweofj", recursive=True)
             out = python(py.name, files).strip()
-        self.assertEqual(out, "['*.faowjefoajweofj']")
+            self.assertEqual(out, "['*.faowjefoajweofj']")
 
     def test_exit_code_with_hasattr(self):
         from sh import ErrorReturnCode

--- a/test.py
+++ b/test.py
@@ -266,17 +266,17 @@ print(sys.argv[1:])
         out = python(py.name, files).strip()
         self.assertEqual(out, "['*.faowjefoajweofj']")
 
+    @unittest.skipUnless(IS_PY3 and MINOR_VER >= 5, "only applicable to Python 3.5 or higher")
     def test_patched_glob_with_recursive_argument(self):
-        if IS_PY3 and MINOR_VER >= 5:
-            from glob import glob
+        from glob import glob
 
-            py = create_tmp_test("""
+        py = create_tmp_test("""
 import sys
 print(sys.argv[1:])
 """)
-            files = glob("*.faowjefoajweofj", recursive=True)
-            out = python(py.name, files).strip()
-            self.assertEqual(out, "['*.faowjefoajweofj']")
+        files = glob("*.faowjefoajweofj", recursive=True)
+        out = python(py.name, files).strip()
+        self.assertEqual(out, "['*.faowjefoajweofj']")
 
     def test_exit_code_with_hasattr(self):
         from sh import ErrorReturnCode


### PR DESCRIPTION
Modification to the `glob` patch to make it forward any `*args` and `**kwargs` to the original `glob` implementation. This adds support for the newly added `recursive` argument in Python 3.5.

See Python 3.5 `glob` documentation:
https://docs.python.org/3/library/glob.html#glob.glob

Resolves #341 