### PR TITLE
Explicitly add support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy3
 
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@
 
 |
 
-sh is a full-fledged subprocess replacement for Python 2.6 - 3.5, PyPy and PyPy3
+sh is a full-fledged subprocess replacement for Python 2.6 - 3.6, PyPy and PyPy3
 that allows you to call any program as if it were a function:
 
 .. code:: python

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Build Tools",

--- a/sh.py
+++ b/sh.py
@@ -2709,7 +2709,7 @@ class StreamWriter(object):
                 # sys.stdout.write(sys.stdin.read())
                 #
                 # then type 'a' followed by ctrl-d 3 times.  in python
-                # 2.6,2.7,3.3,3.4,3.5, it only takes 2 ctrl-d to terminate.
+                # 2.6,2.7,3.3,3.4,3.5,3.6, it only takes 2 ctrl-d to terminate.
                 # however, in python 3.1 and 3.2, it takes all 3.
                 #
                 # so here we send an extra EOF along, just in case.  i don't
@@ -3500,7 +3500,7 @@ if __name__ == "__main__": # pragma: no cover
 
         # if we're testing locally, run all versions of python on the system
         if action == "test":
-            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5")
+            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6")
 
         # if we're testing on travis, just use the system's default python,
         # since travis will spawn a vm per python version in our .travis.yml


### PR DESCRIPTION
- Updated the automated tests to run on Python 3.6;
- Added the version the PyPI classifiers;
- Edited the docs to indicate support up to 3.6;
- Edited a comment about inconsistent ctrl-d behavior in Python
  (tested 3.6 behaves like 3.3-3.5)