### PR TITLE
Normalize get_num_args bahavior

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -114,9 +114,9 @@ import weakref
 PUSHD_LOCK = threading.RLock()
 
 
-if hasattr(inspect, "signature"):
+if hasattr(inspect, "getfullargspec"):
     def get_num_args(fn):
-        return len(inspect.signature(fn).parameters)
+        return len(inspect.getfullargspec(fn).args)
 else:
     def get_num_args(fn):
         return len(inspect.getargspec(fn).args)


### PR DESCRIPTION
Previously the `get_num_args` function, in python 3, returned the length of `inspect.signature(fn).parameters`:
```
>>> import inspect
>>> def hello(a, *args, **kwargs):
...     pass
>>> params = inspect.signature(hello).parameters
>>> params
mappingproxy({'a': <Parameter "a">,
              'args': <Parameter "*args">,
              'kwargs': <Parameter "**kwargs">})
>>> len(params)
3
```
In python 2, `get_num_args`, returned the length of `inspect.getargspec(fn).args`:
```
>>> import inspect
>>> def hello(a, *args, **kwargs):
...     pass
>>> argspec = inspect.getargspec(hello)
>>> argspec
ArgSpec(args=['a'], varargs='args', keywords='kwargs', defaults=None)
>>> len(argspec.args)
1
```

To make this behavior consistent between python2 and python3, the `inspect.getfullargspec(fn)` is used:
```
>>> import inspect
>>> def hello(a, *args, **kwargs):
...     pass
>>> argspec = inspect.getfullargspec(hello)
>>> argspec
FullArgSpec(args=['a'], varargs='args', varkw='kwargs', defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={})
>>> len(argspec.args)
1
```