### PR TITLE
(potential) Fix for issue #398.

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -3430,6 +3430,13 @@ class ModuleImporterFromVariables(object):
         the rest of this function """
 
         parent_frame = inspect.currentframe().f_back
+
+        # Calling PyImport_ImportModule("some_module"); via the C API may not
+        # have a parent frame. Early-out to avoid in_importlib() trying to
+        # get f_code from None when looking for 'some_module'
+        if not parent_frame:
+            return None
+
         while in_importlib(parent_frame):
             parent_frame = parent_frame.f_back
 


### PR DESCRIPTION
Give up on trying to fancy import if there is no parent in the call stack.
This seems to be the case when calling PyImport_ImportModule() from C code,
and if sh has already added itself to sys.meta_path exceptions would be thrown
on subsequent imports.

This fixes my simple test case: i.e calling workaround() is no longer required for the C snippet in #398 to work.

The importlib stuff is a bit magic for me, but I dont *think* this would break existing uses because:
* If parent was ever None before now, things would not be working anyway
* the test suite still passes (on my centos box)

I'd be happy for this to be addressed in another way if preferred, but this would scratch my itch as-is.

Thanks,
Dave M