### PR TITLE
Less verbose logging for process startup on INFO level

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -753,7 +753,7 @@ class RunningCommand(object):
             logger_str = log_str_factory(self.ran, call_args)
             self.log = Logger("command", logger_str)
 
-            self.log.info("starting process")
+            self.log.debug("starting process")
 
             if should_wait:
                 self._spawned_and_waited = True
@@ -798,7 +798,7 @@ class RunningCommand(object):
                 if self.process._stdin_process:
                     self.process._stdin_process.command.wait()
 
-        self.log.info("process completed")
+        self.log.debug("process completed")
         return self
 
 


### PR DESCRIPTION
It is super important to have on INFO level which command is currently running,
but it's super annoying and it makes debugging harder if very long commands get
logged three times (with almost the exact output).

We use sh extensively for short running command invocations (like CLI git
calls) and it's just makes the log unnecessarily very noisy.

I lowered the level for the "starting process" and "process completed" messages,
and kept "process started", because it has the most information about the
process (it includes the PID).

I understand that it can be handy for longer running processes, but in that
case, DEBUG level still can be used.