### PR TITLE
Fix AttributeError on unexpected classes in sys.meta_path

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -3391,7 +3391,12 @@ def register_importer():
     """
 
     def test(importer):
-        return importer.__class__.__name__ == ModuleImporterFromVariables.__name__
+        try:
+            return importer.__class__.__name__ == ModuleImporterFromVariables.__name__
+        except AttributeError:
+            # ran into importer which is not a class instance
+            return False
+
     already_registered = any([True for i in sys.meta_path if test(i)])
 
     if not already_registered:


### PR DESCRIPTION
Fix resolves an exception raised in `register_importer` if any item in `sys.meta_path` is something else than class instance (i.e. doesn't have `__class__` attribute). 

This happens e.g. when using module which has `importlib_metadata` (https://pypi.org/project/importlib-metadata/) as dependency. On import it appends two classes (not instances) to `sys.meta_path` causing `register_importer` to raise `AttributeError`:

```
In [1]: import sys

In [2]: sys.meta_path
Out[2]: 
[<six._SixMetaPathImporter at 0x7f88c2f7f6d0>,
 <pkg_resources.extern.VendorImporter instance at 0x7f88c068e0e0>,
 <pkg_resources._vendor.six._SixMetaPathImporter at 0x7f88c05dd550>]

In [3]: import importlib_metadata

In [4]: sys.meta_path
Out[4]: 
[<six._SixMetaPathImporter at 0x7f88c2f7f6d0>,
 <pkg_resources.extern.VendorImporter instance at 0x7f88c068e0e0>,
 <pkg_resources._vendor.six._SixMetaPathImporter at 0x7f88c05dd550>,
 <class importlib_metadata._common.MetadataPathFinder at 0x7f88be595050>,    # a class!
 <class importlib_metadata._common.WheelMetadataFinder at 0x7f88be595120>]

In [5]: from sh import git
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-bd6124956a85> in <module>()
----> 1 from sh import git

~/.virtualenvs/test/local/lib/python2.7/site-packages/sh.pyc in <module>()
   3581     self = sys.modules[__name__]
   3582     sys.modules[__name__] = SelfWrapper(self)
-> 3583     register_importer()
   3584 

~/.virtualenvs/test/local/lib/python2.7/site-packages/sh.pyc in register_importer()
   3393     def test(importer):
   3394         return importer.__class__.__name__ == ModuleImporterFromVariables.__name__
-> 3395     already_registered = any([True for i in sys.meta_path if test(i)])
   3396 
   3397     if not already_registered:

~/.virtualenvs/test/local/lib/python2.7/site-packages/sh.pyc in test(importer)
   3392 
   3393     def test(importer):
-> 3394         return importer.__class__.__name__ == ModuleImporterFromVariables.__name__
   3395     already_registered = any([True for i in sys.meta_path if test(i)])
   3396 

AttributeError: class MetadataPathFinder has no attribute '__class__'
```