### PR TITLE
Raising exceptions should use native strings.

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -387,6 +387,12 @@ class ErrorReturnCode(Exception):
             stderr=exc_stderr.decode(DEFAULT_ENCODING, "replace")
         )
 
+        if not IS_PY3:
+            # Exception messages should be treated as an API which takes native str type on both
+            # Python2 and Python3.  (Meaning, it's a byte string on Python2 and a text string on
+            # Python3)
+            msg = encode_to_py3bytes_or_py2str(msg)
+
         super(ErrorReturnCode, self).__init__(msg)
 
 

--- a/test.py
+++ b/test.py
@@ -245,16 +245,15 @@ class FunctionalTests(BaseTests):
         py = create_tmp_test("exit(1)")
 
         arg = "漢字"
+        native_arg = arg
         if not IS_PY3:
             arg = arg.decode("utf8")
+
 
         try:
             python(py.name, arg, _encoding="utf8")
         except ErrorReturnCode as e:
-            if IS_PY3:
-                self.assertTrue(arg in str(e))
-            else:
-                self.assertTrue(arg in unicode(e))
+            self.assertTrue(native_arg in str(e))
         else:
             self.fail("exception wasn't raised")
 


### PR DESCRIPTION
In Python3, the str type is a text string.  On Python2, the str type is
a byte string.  When we raise exceptions we should use native strings
otherwise Python may end up truncating or omitting the exception
message (on Python2) or mangling them (if a byte string were to be given
on Python3).

Fixes #463 

(Note, if you want some more examples of this outside of sh code, you can take a look at this documentation I wrote for the kitchen library: https://pythonhosted.org/kitchen/unicode-frustrations.html#frustration-5-exceptions )