### PR TITLE
Use raw string to avoid invalid escape deprecation warning.

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -421,7 +421,7 @@ class CommandNotFound(AttributeError): pass
 
 
 
-rc_exc_regex = re.compile("(ErrorReturnCode|SignalException)_((\d+)|SIG[a-zA-Z]+)")
+rc_exc_regex = re.compile(r"(ErrorReturnCode|SignalException)_((\d+)|SIG[a-zA-Z]+)")
 rc_exc_cache = {}
 
 SIGNAL_MAPPING = {}


### PR DESCRIPTION
See https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior for this newly added warning as of 3.6.  This change should be fully backwards compatible.