### PR TITLE
Makes testing easier with a docker build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,21 +49,24 @@ Developers
 Testing
 -------
 
-First install the development requirements::
+I've included a Docker test suite in the `docker_test_suit/` folder.  To build the image, `cd` into that directory and
+run::
 
-    $> pip install -r requirements-dev.txt
+    $> ./build.sh
 
-The run the tests for all Python versions on your system::
+This will install ubuntu 18.04 LTS and all python versions from 2.6-3.8.  Once it's done, stay in that directory and
+run::
 
-    $> python sh.py test
+    $> ./run.sh
 
-To run a single test for all environments::
+This will mount your local code directory into the container and start the test suite, which will take a long time to
+run.  If you wish to run a single test, you may pass that test to `./run.sh`::
 
-    $> python sh.py test FunctionalTests.test_unicode_arg
+    $> ./run.sh FunctionalTests.test_unicode_arg
 
 To run a single test for a single environment::
 
-    $> python sh.py test -e 3.4 FunctionalTests.test_unicode_arg
+    $> ./run.sh -e 3.4 FunctionalTests.test_unicode_arg
 
 Coverage
 --------

--- a/docker_test_suite/Dockerfile
+++ b/docker_test_suite/Dockerfile
@@ -43,4 +43,4 @@ RUN pip install -r /tmp/requirements-dev.txt
 
 USER shtest
 WORKDIR /home/shtest/sh
-ENTRYPOINT python sh.py test
+ENTRYPOINT ["python", "sh.py", "test"]

--- a/docker_test_suite/Dockerfile
+++ b/docker_test_suite/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:bionic
+
+ARG cache_bust
+RUN apt-get update
+RUN apt-get -y install locales
+
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8 
+
+RUN apt-get -y install\
+    software-properties-common\
+    curl\
+    sudo\
+    python
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
+RUN apt-get -y install\
+    python2.6\
+    python2.7\
+    python3.1\
+    python3.2\
+    python3.3\
+    python3.4\
+    python3.5\
+    python3.6\
+    python3.7\
+    python3.8
+
+RUN apt-get -y install python3-distutils\
+    && curl https://bootstrap.pypa.io/get-pip.py | python -
+
+ARG uid=1000
+RUN groupadd -g $uid shtest\
+    && useradd -m -u $uid -g $uid shtest\
+    && gpasswd -a shtest sudo\
+    && echo "shtest:shtest" | chpasswd
+
+COPY requirements-dev.txt /tmp/
+RUN pip install -r /tmp/requirements-dev.txt
+
+USER shtest
+WORKDIR /home/shtest/sh
+ENTRYPOINT python sh.py test

--- a/docker_test_suite/build.sh
+++ b/docker_test_suite/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cp ../requirements-dev.txt .
+docker build -t amoffat/shtest .

--- a/docker_test_suite/requirements-dev.txt
+++ b/docker_test_suite/requirements-dev.txt
@@ -1,0 +1,6 @@
+Pygments==2.1.3
+coverage==4.2
+coveralls==1.1
+docopt==0.6.2
+docutils==0.12
+requests==2.12.1

--- a/docker_test_suite/requirements-dev.txt
+++ b/docker_test_suite/requirements-dev.txt
@@ -1,6 +1,0 @@
-Pygments==2.1.3
-coverage==4.2
-coveralls==1.1
-docopt==0.6.2
-docutils==0.12
-requests==2.12.1

--- a/docker_test_suite/run.sh
+++ b/docker_test_suite/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -ex
+docker run -it --rm -v $(pwd)/../:/home/shtest/sh amoffat/shtest

--- a/docker_test_suite/run.sh
+++ b/docker_test_suite/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -ex
-docker run -it --rm -v $(pwd)/../:/home/shtest/sh amoffat/shtest
+docker run -it --rm -v $(pwd)/../:/home/shtest/sh amoffat/shtest $@

--- a/sh.py
+++ b/sh.py
@@ -3517,7 +3517,7 @@ if __name__ == "__main__": # pragma: no cover
     if args:
         action = args[0]
 
-    if action in ("test", "travis"):
+    if action in ("test", "travis", "tox"):
         import test
         coverage = None
         if test.HAS_UNICODE_LITERAL:
@@ -3530,12 +3530,11 @@ if __name__ == "__main__": # pragma: no cover
 
         # if we're testing locally, run all versions of python on the system
         if action == "test":
-            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6")
+            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8")
 
-        # if we're testing on travis, just use the system's default python,
-        # since travis will spawn a vm per python version in our .travis.yml
-        # file
-        elif action == "travis":
+        # if we're testing on travis or tox, just use the system's default python, since travis will spawn a vm per
+        # python version in our .travis.yml file, and tox will run its matrix via tox.ini
+        elif action in ("travis", "tox"):
             v = sys.version_info
             sys_ver = "%d.%d" % (v[0], v[1])
             all_versions = (sys_ver,)

--- a/sh.py
+++ b/sh.py
@@ -3545,17 +3545,21 @@ if __name__ == "__main__": # pragma: no cover
 
         all_locales = ("en_US.UTF-8", "C")
         i = 0
+        ran_versions = set()
         for locale in all_locales:
+            # make sure this locale is allowed
             if constrain_locales and locale not in constrain_locales:
                 continue
 
             for version in all_versions:
+                # make sure this version is allowed
                 if constrain_versions and version not in constrain_versions:
                     continue
 
                 for force_select in all_force_select:
                     env_copy = env.copy()
 
+                    ran_versions.add(version)
                     exit_code = run_tests(env_copy, locale, args, version,
                             force_select, SH_TEST_RUN_IDX=i)
 
@@ -3568,8 +3572,7 @@ if __name__ == "__main__": # pragma: no cover
 
                     i += 1
 
-        ran_versions = ",".join(all_versions)
-        print("Tested Python versions: %s" % ran_versions)
+        print("Tested Python versions: %s" % ",".join(sorted(list(ran_versions))))
 
     else:
         env = Environment(globals())

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{27,35,36,37,38},docs
+# virtualenv for py26 is broken, so don't put it here
+envlist = py{27,31,32,33,34,35,36,37,38},docs
 
 [testenv]
 deps = -r requirements-dev.txt
 commands =
-    python sh.py travis
+    python sh.py tox
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This PR adds the ability to run the tests across all sh-supported Python versions, using Docker

I went with using raw `python sh.py test` inside of the image, instead of `tox` because virtualenv is broken on python2.6, and so we can't include 2.6 in the tox env list.  Also, tox blows up when we try to do parallel builds, and I don't feel like looking at it.

To run, see the changes to Readme.rst in this PR