### PR TITLE
Enable testing on Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ os:
 language: python
 
 python:
-    - 2.6
+    # - 2.6 No longer supported on Travis
     - 2.7
     - pypy
-    - 3.3
+    # - 3.3 No longer supported on Travis
     - 3.4
     - 3.5
     - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,11 @@ os:
 language: python
 
 python:
-    - 2.6
-    - 2.7
     - pypy
-    - 3.3
-    - 3.4
     - 3.5
     - 3.6
-    - pypy-5.3.1
+    - 3.7
+    - 3.8
 
 before_script:
     - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ os:
 language: python
 
 python:
+    - 2.6
+    - 2.7
     - pypy
+    - 3.3
+    - 3.4
     - 3.5
     - 3.6
     - 3.7

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Build Tools",

--- a/sh.py
+++ b/sh.py
@@ -3530,7 +3530,7 @@ if __name__ == "__main__": # pragma: no cover
 
         # if we're testing locally, run all versions of python on the system
         if action == "test":
-            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6")
+            all_versions = ("2.6", "2.7", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8")
 
         # if we're testing on travis, just use the system's default python,
         # since travis will spawn a vm per python version in our .travis.yml

--- a/test.py
+++ b/test.py
@@ -506,41 +506,30 @@ while True:
         # this is the environment we'll pass into our commands
         env = {"HERP": "DERP"}
 
-        # python on osx will bizarrely add some extra environment variables that
-        # i didn't ask for.  for this test, we prune those out if they exist
-        osx_cruft = [
-            "__CF_USER_TEXT_ENCODING",
-            "__PYVENV_LAUNCHER__",
-            "VERSIONER_PYTHON_PREFER_32_BIT",
-            "VERSIONER_PYTHON_VERSION",
-        ]
-
         # first we test that the environment exists in our child process as
         # we've set it
         py = create_tmp_test("""
 import os
 
-osx_cruft = %s
-for key in osx_cruft:
-    try: del os.environ[key]
-    except: pass
-print(os.environ["HERP"] + " " + str(len(os.environ)))
-""" % osx_cruft)
+for key in list(os.environ.keys()):
+    if key != "HERP":
+        del os.environ[key]
+print(dict(os.environ))
+""")
         out = python(py.name, _env=env).strip()
-        self.assertEqual(out, "DERP 1")
+        self.assertEqual(out, "{'HERP': 'DERP'}")
 
         py = create_tmp_test("""
 import os, sys
 sys.path.insert(0, os.getcwd())
 import sh
-osx_cruft = %s
-for key in osx_cruft:
-    try: del os.environ[key]
-    except: pass
-print(sh.HERP + " " + str(len(os.environ)))
-""" % osx_cruft)
+for key in list(os.environ.keys()):
+    if key != "HERP":
+        del os.environ[key]
+print(dict(HERP=sh.HERP))
+""")
         out = python(py.name, _env=env, _cwd=THIS_DIR).strip()
-        self.assertEqual(out, "DERP 1")
+        self.assertEqual(out, "{'HERP': 'DERP'}")
 
 
     def test_which(self):


### PR DESCRIPTION
Fixes `test_environment` to also work on these versions.

Removes support for Python versions which are EOL.

Fixes #498

Replaces #468