### PR TITLE
re-raise an exception if we were unable to handle it

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -3550,7 +3550,7 @@ class SelfWrapper(ModuleType):
             # top stack frame
             # Older versions of pypy don't set parent[1] the same way as CPython or newer versions
             # of Pypy so we have to special case that too.
-            if (parent[1] in ('<stdin>', '<string>') or
+            if parent[1] in ('<stdin>', '<string>') or (
                     parent[1] == '<module>' and platform.python_implementation().lower() == 'pypy'):
                 # This depends on things like Python's calling convention and the layout of stack
                 # frames but it's a fix for a bug in a very cornery cornercase so....

--- a/sh.py
+++ b/sh.py
@@ -3550,11 +3550,13 @@ class SelfWrapper(ModuleType):
             # top stack frame
             # Older versions of pypy don't set parent[1] the same way as CPython or newer versions
             # of Pypy so we have to special case that too.
-            if parent[1] in ('<stdin>', '<string>') or (
+            if (parent[1] in ('<stdin>', '<string>') or
                     parent[1] == '<module>' and platform.python_implementation().lower() == 'pypy'):
                 # This depends on things like Python's calling convention and the layout of stack
                 # frames but it's a fix for a bug in a very cornery cornercase so....
                 module_name = parent[0].f_code.co_names[-1]
+            else:
+                raise
         else:
             parsed = ast.parse(code)
             try:


### PR DESCRIPTION
If we get TypeError from finding the module_name but it's not in the
situation that we know what to do, we should re-raise the exception so
that it's easier to track down where the error is coming from