### PR TITLE
None should not render an arg. closes #522

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1581,7 +1581,7 @@ def compile_args(args, kwargs, sep, prefix):
                 processed_args.append(encode(sub_arg))
         elif isinstance(arg, dict):
             processed_args += aggregate_keywords(arg, sep, prefix, raw=True)
-        elif arg is None:
+        elif arg is None or arg is False:
             pass
         else:
             processed_args.append(encode(arg))

--- a/sh.py
+++ b/sh.py
@@ -1581,6 +1581,8 @@ def compile_args(args, kwargs, sep, prefix):
                 processed_args.append(encode(sub_arg))
         elif isinstance(arg, dict):
             processed_args += aggregate_keywords(arg, sep, prefix, raw=True)
+        elif arg is None:
+            pass
         else:
             processed_args.append(encode(arg))
 

--- a/sh.py
+++ b/sh.py
@@ -1581,6 +1581,8 @@ def compile_args(args, kwargs, sep, prefix):
                 processed_args.append(encode(sub_arg))
         elif isinstance(arg, dict):
             processed_args += aggregate_keywords(arg, sep, prefix, raw=True)
+
+        # see https://github.com/amoffat/sh/issues/522
         elif arg is None or arg is False:
             pass
         else:

--- a/test.py
+++ b/test.py
@@ -383,6 +383,21 @@ exit(3)
         py = create_tmp_test("exit(0)")
         python(py.name, _ok_code=None)
 
+
+    def test_none_arg(self):
+        py = create_tmp_test("""
+import sys
+print(sys.argv[1:])
+""")
+        maybe_arg = "some"
+        out = python(py.name, maybe_arg).strip()
+        self.assertEqual(out, "['some']")
+
+        maybe_arg = None
+        out = python(py.name, maybe_arg).strip()
+        self.assertEqual(out, "[]")
+
+
     def test_quote_escaping(self):
         py = create_tmp_test("""
 from optparse import OptionParser

--- a/test.py
+++ b/test.py
@@ -836,6 +836,17 @@ print(options.long_option)
         self.assertTrue(python(py.name).strip() == "False")
 
 
+    def test_false_bool_ignore(self):
+        py = create_tmp_test("""
+import sys
+print(sys.argv[1:])
+""")
+        test = True
+        self.assertEqual(python(py.name, test and "-n").strip(), "['-n']")
+        test = False
+        self.assertEqual(python(py.name, test and "-n").strip(), "[]")
+
+
     def test_composition(self):
         from sh import ls, wc
         c1 = int(wc(ls("-A1"), l=True))


### PR DESCRIPTION
Pretty simple. Before, a `None` argument passed to a command was being passed in as a string. Now, it omits the argument altogether.