### PR TITLE
_env just needs to be a Mapping

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -52,7 +52,7 @@ import inspect
 import tempfile
 import warnings
 import stat
-from collections import deque
+from collections import deque, Mapping
 import glob as glob_module
 import ast
 from contextlib import contextmanager
@@ -110,7 +110,6 @@ import tty
 import fcntl
 import struct
 import resource
-from collections import deque
 import logging
 import weakref
 
@@ -1146,8 +1145,8 @@ def env_validator(passed_kwargs, merged_kwargs):
     if env is None:
         return invalid
 
-    if not isinstance(env, dict):
-        invalid.append(("env", "env must be a dict. Got {!r}".format(env)))
+    if not isinstance(env, Mapping):
+        invalid.append(("env", "env must be dict-like. Got {!r}".format(env)))
         return invalid
 
     for k, v in passed_kwargs["env"].items():

--- a/test.py
+++ b/test.py
@@ -558,6 +558,11 @@ print(dict(HERP=sh.HERP))
         out = python(py.name, _env=env, _cwd=THIS_DIR).strip()
         self.assertEqual(out, "{'HERP': 'DERP'}")
 
+        # Test that _env also accepts os.environ which is a mpping but not a dict.
+        os.environ["HERP"] = "DERP"
+        out = python(py.name, _env=os.environ, _cwd=THIS_DIR).strip()
+        self.assertEqual(out, "{'HERP': 'DERP'}")
+
 
     def test_which(self):
         from sh import which, ls


### PR DESCRIPTION
This allows other values, as long as they implement the Mapping interface, i.e. `.items()`.

Fixes #527