### PR TITLE
File cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = 
+source =
     sh.py
 
 [report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
 
 script:
     - python sh.py travis
+    - python -m flake8 sh.py
     - if python -c 'import sys; sys.exit(int(not sys.version_info >= (3, 5)))' ; then python setup.py check --restructuredtext --metadata --strict ; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 
 script:
     - python sh.py travis
-    - python -m flake8 sh.py
+    - python -m flake8 sh.py test.py
     - if python -c 'import sys; sys.exit(int(not sys.version_info >= (3, 5)))' ; then python setup.py check --restructuredtext --metadata --strict ; fi
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@
 *   Bugfix where input arguments were being assumed as ascii or unicode, but never as a string in a different encoding.
 *   _long_sep keyword argument added joining together a dictionary of arguments passed in to a command
 *   Commands can now be passed a dictionary of args, and the keys will be interpretted "raw", with no underscore-to-hyphen conversion
-*   Reserved Python keywords can now be used as subcommands by appending an underscore `_` to them 
+*   Reserved Python keywords can now be used as subcommands by appending an underscore `_` to them
 
 
 ## 1.07 - 11/21/12
@@ -180,7 +180,7 @@
 *   Added `_decode_errors` to be passed to all stdout/stderr decoding of a process.
 *   Added `_no_out`, `_no_err`, and `_no_pipe` special keyword arguments.  These are used for long-running processes with lots of output.
 *   Changed custom loggers that were created for each process to fixed loggers, so there are no longer logger references laying around in the logging module after the process ends and it garbage collected.
-    
+
 
 ## 1.06 - 11/10/12
 
@@ -195,11 +195,11 @@
 
 *   Changing status from alpha to beta.
 *   Python 3.3 officially supported.
-*   Documentation fix.  The section on exceptions now references the fact that signals do not raise an exception, even for signals that might seem like they should, e.g. segfault.  
+*   Documentation fix.  The section on exceptions now references the fact that signals do not raise an exception, even for signals that might seem like they should, e.g. segfault.
 *   Bugfix with Python 3.3 where importing commands from the sh namespace resulted in an error related to `__path__`
 *   Long-form and short-form options to commands may now be given False to disable the option from being passed into the command.  This is useful to pass in a boolean flag that you flip to either True or False to enable or disable some functionality at runtime.
 
 ## 1.04 - 10/07/12
 
-*   Making `Command` class resolve the `path` parameter with `which` by default instead of expecting it to be resolved before it is passed in.  This change shouldn't affect backwards compatibility.  
+*   Making `Command` class resolve the `path` parameter with `which` by default instead of expecting it to be resolved before it is passed in.  This change shouldn't affect backwards compatibility.
 *   Fixing a bug when an exception is raised from a program, and the error output has non-ascii text.  This didn't work in Python < 3.0, because .decode()'s default encoding is typically ascii.

--- a/docker_test_suite/Dockerfile
+++ b/docker_test_suite/Dockerfile
@@ -4,10 +4,10 @@ ARG cache_bust
 RUN apt-get update
 RUN apt-get -y install locales
 
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 RUN apt-get -y install\
     software-properties-common\

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ coverage==4.2
 coveralls==1.1
 docopt==0.6.2
 docutils==0.12
+flake8==3.7.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.txt
+
+[flake8]
+max-line-length = 120

--- a/sh.py
+++ b/sh.py
@@ -349,19 +349,19 @@ class ErrorReturnCode(Exception):
     derived classes with the format: ErrorReturnCode_NNN where NNN is the exit
     code number.  the reason for this is it reduces boiler plate code when
     testing error return codes:
-    
+
         try:
             some_cmd()
         except ErrorReturnCode_12:
             print("couldn't do X")
-            
+
     vs:
         try:
             some_cmd()
         except ErrorReturnCode as e:
             if e.exit_code == 12:
                 print("couldn't do X")
-    
+
     it's not much of a savings, but i believe it makes the code easier to read """
 
     truncate_cap = 750
@@ -612,7 +612,7 @@ class Logger(object):
     script is done.  with sh, it's easy to create loggers with unique names if
     we want our loggers to include our command arguments.  for example, these
     are all unique loggers:
-        
+
             ls -l
             ls -l /tmp
             ls /tmp
@@ -746,7 +746,7 @@ class RunningCommand(object):
 
         done_callback = call_args["done"]
         if done_callback:
-            call_args["done"] = partial(done_callback, self) 
+            call_args["done"] = partial(done_callback, self)
 
 
         # set up which stream should write to the pipe
@@ -846,7 +846,7 @@ class RunningCommand(object):
 
             else:
                 self.handle_command_exit_code(exit_code)
-        
+
                 # if an iterable command is using an instance of OProc for its stdin,
                 # wait on it.  the process is probably set to "piped", which means it
                 # won't be waited on, which means exceptions won't propagate up to the
@@ -1137,7 +1137,7 @@ def bufsize_validator(passed_kwargs, merged_kwargs):
 
 
 def env_validator(passed_kwargs, merged_kwargs):
-    """ a validator to check that env is a dictionary and that all environment variable 
+    """ a validator to check that env is a dictionary and that all environment variable
     keys and values are strings. Otherwise, we would exit with a confusing exit code 255. """
     invalid = []
 
@@ -1163,7 +1163,7 @@ class Command(object):
     represents the program itself (and not a running instance of it), it should
     hold very little state.  in fact, the only state it does hold is baked
     arguments.
-    
+
     when a Command object is called, the result that is returned is a
     RunningCommand object, which represents the Command put into an execution
     state. """
@@ -1322,7 +1322,7 @@ class Command(object):
         # exception.  if CommandNotFound is raised, we need self._path and the
         # other attributes to be set correctly, so repr() works when they're
         # inspecting the stack.  issue #304
-        self._path = encode_to_py3bytes_or_py2str(found) 
+        self._path = encode_to_py3bytes_or_py2str(found)
         self.__name__ = str(self)
 
 
@@ -1544,7 +1544,7 @@ class Command(object):
         stderr = call_args["err"]
         if output_redirect_is_filename(stderr):
             stderr = open(str(stderr), "wb")
-    
+
         return RunningCommand(cmd, call_args, stdin, stdout, stderr)
 
 
@@ -1565,7 +1565,7 @@ def compile_args(args, kwargs, sep, prefix):
     and produces
 
         ['-l', '/tmp', '--color=never']
-        
+
     """
     processed_args = []
     encode = encode_to_py3bytes_or_py2str
@@ -1998,7 +1998,7 @@ class OProc(object):
             # parent reading the read end won't block (close breaks the block).
             flags = fcntl.fcntl(exc_pipe_write, fcntl.F_GETFD)
             flags |= fcntl.FD_CLOEXEC
-            fcntl.fcntl(exc_pipe_write, fcntl.F_SETFD, flags) 
+            fcntl.fcntl(exc_pipe_write, fcntl.F_SETFD, flags)
 
             try:
                 # ignoring SIGHUP lets us persist even after the parent process
@@ -2585,7 +2585,7 @@ def background_thread(timeout_fn, timeout_event, handle_exit_code, is_alive,
         quit):
     """ handles the timeout logic """
 
-    # if there's a timeout event, loop 
+    # if there's a timeout event, loop
     if timeout_event:
         while not quit.is_set():
             timed_out = event_wait(timeout_event, 0.1)
@@ -2667,7 +2667,7 @@ class NotYetReadyToRead(Exception): pass
 def determine_how_to_read_input(input_obj):
     """ given some kind of input object, return a function that knows how to
     read chunks of that input object.
-    
+
     each reader function should return a chunk and raise a DoneReadingForever
     exception, or return None, when there's no more data to read
 
@@ -3315,7 +3315,7 @@ class Environment(dict):
     def __init__(self, globs, baked_args={}):
         """ baked_args are defaults for the 'sh' execution context.  for
         example:
-            
+
             tmp = sh(_out=StringIO())
 
         'out' would end up in here as an entry in the baked_args dict """
@@ -3672,7 +3672,7 @@ class ModuleImporterFromVariables(object):
 
         sh2 = sh(_timeout=3)
         from sh2 import ls
-    
+
     """
 
     def __init__(self, restrict_to=None):

--- a/sh.py
+++ b/sh.py
@@ -62,8 +62,10 @@ MINOR_VER = sys.version_info[1]
 IS_PY26 = sys.version_info[0] == 2 and MINOR_VER == 6
 if IS_PY3:
     from io import StringIO
+
     ioStringIO = StringIO
     from io import BytesIO as cStringIO
+
     iocStringIO = cStringIO
     from queue import Queue, Empty
 
@@ -82,7 +84,6 @@ try:
     from shlex import quote as shlex_quote  # here from 3.3 onward
 except ImportError:
     from pipes import quote as shlex_quote  # undocumented before 2.7
-
 
 if "windows" in platform.system().lower():  # pragma: no cover
     raise ImportError("sh %s is currently only supported on linux and osx. \
@@ -108,7 +109,6 @@ FORCE_USE_SELECT = bool(int(os.environ.get("SH_TESTS_USE_SELECT", "0")))
 # with-context
 PUSHD_LOCK = threading.RLock()
 
-
 if hasattr(inspect, "getfullargspec"):
     def get_num_args(fn):
         return len(inspect.getfullargspec(fn).args)
@@ -129,7 +129,6 @@ POLLER_EVENT_READ = 1
 POLLER_EVENT_WRITE = 2
 POLLER_EVENT_HUP = 4
 POLLER_EVENT_ERROR = 8
-
 
 # here we use an use a poller interface that transparently selects the most
 # capable poller (out of either select.select or select.poll).  this was added
@@ -325,6 +324,7 @@ class ErrorReturnCodeMeta(type):
     program we're testing throws may not be the same class that we pass to
     assertRaises
     """
+
     def __subclasscheck__(self, o):
         other_bases = set([b.__name__ for b in o.__bases__])
         return self.__name__ in other_bases or o.__name__ == self.__name__
@@ -402,6 +402,7 @@ class SignalException(ErrorReturnCode):
 class TimeoutException(Exception):
     """ the exception thrown when a command is killed because a specified
     timeout (via _timeout or .wait(timeout)) was hit """
+
     def __init__(self, exit_code, full_cmd):
         self.exit_code = exit_code
         self.full_cmd = full_cmd
@@ -611,6 +612,7 @@ class Logger(object):
     "context", which will be the very unique name.  this allows us to get a
     logger with a very general name, eg: "command", and have a unique name
     appended to it via the context, eg: "ls -l /tmp" """
+
     def __init__(self, name, context=None):
         self.name = name
         self.log = logging.getLogger("%s.%s" % (SH_LOGGER_NAME, name))
@@ -937,6 +939,7 @@ class RunningCommand(object):
 
     def __eq__(self, other):
         return unicode(self) == unicode(other)
+
     __hash__ = None  # Avoid DeprecationWarning in Python < 3
 
     def __contains__(self, item):
@@ -2107,7 +2110,7 @@ class OProc(object):
                 os.close(close_pipe_write)
 
             os.close(exc_pipe_write)
-            fork_exc = os.read(exc_pipe_read, 1024**2)
+            fork_exc = os.read(exc_pipe_read, 1024 ** 2)
             os.close(exc_pipe_read)
             if fork_exc:
                 fork_exc = fork_exc.decode(DEFAULT_ENCODING)
@@ -2183,8 +2186,7 @@ class OProc(object):
             # wherever it has to go, sometimes a pipe Queue (that we will use
             # to pipe data to other processes), and also an internal deque
             # that we use to aggregate all the output
-            save_stdout = not ca["no_out"] and \
-                (tee_out or stdout is None)
+            save_stdout = not ca["no_out"] and (tee_out or stdout is None)
 
             pipe_out = ca["piped"] in ("out", True)
             pipe_err = ca["piped"] in ("err",)
@@ -2213,15 +2215,13 @@ class OProc(object):
             # stream reader for stderr, because we've already set one up for
             # stdout above
             self._stderr_stream = None
-            if stderr is not OProc.STDOUT and not single_tty and not pipe_err \
-                    and self._stderr_parent_fd:
+            if stderr is not OProc.STDOUT and not single_tty and not pipe_err and self._stderr_parent_fd:
 
                 stderr_pipe = None
                 if pipe is OProc.STDERR and not ca["no_pipe"]:
                     stderr_pipe = self._pipe_queue
 
-                save_stderr = not ca["no_err"] and \
-                    (ca["tee"] in ("err",) or stderr is None)
+                save_stderr = not ca["no_err"] and (ca["tee"] in ("err",) or stderr is None)
 
                 if callable(stderr):
                     stderr = construct_streamreader_callback(self, stderr)
@@ -2259,6 +2259,7 @@ class OProc(object):
                 def fn(exit_code):
                     with process_assign_lock:
                         return self.command.handle_command_exit_code(exit_code)
+
                 handle_exit_code = fn
 
             self._quit_threads = threading.Event()
@@ -2656,6 +2657,7 @@ def determine_how_to_read_input(input_obj):
 
         def raise_():
             raise DoneReadingForever
+
         get_chunk = raise_
 
     else:
@@ -2679,6 +2681,7 @@ def get_queue_chunk_reader(stdin):
         if chunk is None:
             raise DoneReadingForever
         return chunk
+
     return fn
 
 
@@ -2717,6 +2720,7 @@ def get_iter_chunk_reader(stdin):
             return chunk
         except StopIteration:
             raise DoneReadingForever
+
     return fn
 
 
@@ -2970,6 +2974,7 @@ def get_stringio_chunk_consumer(handler, encoding, decode_errors):
 class StreamReader(object):
     """ reads from some output (the stream) and sends what it just read to the
     handler.  """
+
     def __init__(self, log, stream, handler, buffer, bufsize_type, encoding, decode_errors, pipe_queue=None,
                  save_data=True):
         self.stream = stream
@@ -3170,7 +3175,9 @@ def with_lock(lock):
             with lock:
                 with fn(*a, **kwargs):
                     yield
+
         return wrapped2
+
     return wrapped
 
 
@@ -3327,7 +3334,6 @@ class Contrib(ModuleType):  # pragma: no cover
     @classmethod
     def __call__(cls, name):
         def wrapper1(fn):
-
             @property
             def cmd_getter(self):
                 cmd = resolve_command(name)
@@ -3567,6 +3573,7 @@ def register_importer():
         tmp = sh()
         from tmp import ls
     """
+
     def test(importer_cls):
         try:
             return importer_cls.__class__.__name__ == ModuleImporterFromVariables.__name__
@@ -3577,7 +3584,7 @@ def register_importer():
     already_registered = any([True for i in sys.meta_path if test(i)])
 
     if not already_registered:
-        importer = ModuleImporterFromVariables(restrict_to=[SelfWrapper.__name__],)
+        importer = ModuleImporterFromVariables(restrict_to=[SelfWrapper.__name__], )
         sys.meta_path.insert(0, importer)
 
     return not already_registered

--- a/sh.py
+++ b/sh.py
@@ -409,7 +409,7 @@ class TimeoutException(Exception):
         super(Exception, self).__init__()
 
 
-SIGNALS_THAT_SHOULD_THROW_EXCEPTION = {
+SIGNALS_THAT_SHOULD_THROW_EXCEPTION = set((
     signal.SIGABRT,
     signal.SIGBUS,
     signal.SIGFPE,
@@ -421,7 +421,7 @@ SIGNALS_THAT_SHOULD_THROW_EXCEPTION = {
     signal.SIGSEGV,
     signal.SIGTERM,
     signal.SIGSYS,
-}
+))
 
 
 # we subclass AttributeError because:
@@ -434,7 +434,7 @@ class CommandNotFound(AttributeError):
 rc_exc_regex = re.compile(r"(ErrorReturnCode|SignalException)_((\d+)|SIG[a-zA-Z]+)")
 rc_exc_cache = {}
 
-SIGNAL_MAPPING = {v: k for k, v in signal.__dict__.items() if re.match(r"SIG[a-zA-Z]+", k)}
+SIGNAL_MAPPING = dict([(v, k) for k, v in signal.__dict__.items() if re.match(r"SIG[a-zA-Z]+", k)])
 
 
 def get_exc_from_name(name):
@@ -670,7 +670,7 @@ class RunningCommand(object):
     exceptions. """
 
     # these are attributes that we allow to passthrough to OProc
-    _OProc_attr_whitelist = {
+    _OProc_attr_whitelist = set((
         "signal",
         "terminate",
         "kill",
@@ -684,7 +684,7 @@ class RunningCommand(object):
         "input_thread_exc",
         "output_thread_exc",
         "bg_thread_exc",
-    }
+    ))
 
     def __init__(self, cmd, call_args, stdin, stdout, stderr):
         """
@@ -1085,7 +1085,7 @@ def fg_validator(passed_kwargs, merged_kwargs):
 _fg is invalid with nearly every other option, see warning and workaround here:
 
     https://amoffat.github.io/sh/sections/special_arguments.html#fg"""
-    whitelist = {"env", "fg", "cwd"}
+    whitelist = set(("env", "fg", "cwd"))
     offending = set(passed_kwargs.keys()) - whitelist
 
     if "fg" in passed_kwargs and passed_kwargs["fg"] and offending:
@@ -2053,7 +2053,7 @@ class OProc(object):
                     close_fds = True
 
                 if close_fds:
-                    pass_fds = {0, 1, 2, exc_pipe_write}
+                    pass_fds = set((0, 1, 2, exc_pipe_write))
                     pass_fds.update(ca["pass_fds"])
 
                     # don't inherit file descriptors
@@ -3231,7 +3231,7 @@ class Environment(dict):
     # not resolve to functions.  we don't want to accidentally shadow real
     # commands with functions/imports that we define in sh.py.  for example,
     # "import time" may override the time system program
-    whitelist = {
+    whitelist = set((
         "Command",
         "RunningCommand",
         "CommandNotFound",
@@ -3249,7 +3249,7 @@ class Environment(dict):
         "pushd",
         "glob",
         "contrib",
-    }
+    ))
 
     def __init__(self, globs, baked_args=None):
         """ baked_args are defaults for the 'sh' execution context.  for

--- a/sh.py
+++ b/sh.py
@@ -772,7 +772,7 @@ class RunningCommand(object):
                                      self.call_args, pipe, process_assign_lock)
 
             logger_str = log_str_factory(self.ran, call_args, self.process.pid)
-            self.log.set_context(logger_str)
+            self.log.context = self.log.sanitize_context(logger_str)
             self.log.info("process started")
 
             if should_wait:

--- a/test.py
+++ b/test.py
@@ -1,6 +1,23 @@
 # -*- coding: utf8 -*-
-import sys
+from contextlib import contextmanager
+from functools import wraps
+from os.path import exists, join, realpath, dirname, split
+import errno
+import fcntl
+import inspect
+import logging
 import os
+import platform
+import pty
+import resource
+import sh
+import signal
+import stat
+import sys
+import tempfile
+import time
+import unittest
+import warnings
 
 IS_PY3 = sys.version_info[0] == 3
 IS_PY2 = not IS_PY3
@@ -33,31 +50,12 @@ if HAS_UNICODE_LITERAL:
 
         cov.start()
 
-
-from os.path import exists, join, realpath, dirname, split
-import unittest
 try:
     import unittest.mock
 except ImportError:
     HAS_MOCK = False
 else:
     HAS_MOCK = True
-import tempfile
-import warnings
-import pty
-import resource
-import logging
-import sys
-from contextlib import contextmanager
-import sh
-import signal
-import errno
-import stat
-import fcntl
-import platform
-from functools import wraps
-import time
-import inspect
 
 # we have to use the real path because on osx, /tmp is a symlink to
 # /private/tmp, and so assertions that gettempdir() == sh.pwd() will fail
@@ -75,6 +73,7 @@ def append_pythonpath(env, path):
     pypath = ":".join(pypath)
     env[key] = pypath
 
+
 def get_module_import_dir(m):
     mod_file = inspect.getsourcefile(m)
     is_package = mod_file.endswith("__init__.py")
@@ -84,9 +83,9 @@ def get_module_import_dir(m):
         mod_dir, _ = split(mod_dir)
     return mod_dir
 
+
 def append_module_path(env, m):
     append_pythonpath(env, get_module_import_dir(m))
-
 
 
 if IS_PY3:
@@ -94,8 +93,10 @@ if IS_PY3:
     unicode = str
     long = int
     from io import StringIO
+
     ioStringIO = StringIO
     from io import BytesIO as cStringIO
+
     iocStringIO = cStringIO
 else:
     from StringIO import StringIO
@@ -113,7 +114,6 @@ baked_env = os.environ.copy()
 append_module_path(baked_env, sh)
 python = system_python.bake(_env=baked_env)
 
-
 if hasattr(logging, 'NullHandler'):
     NullHandler = logging.NullHandler
 else:
@@ -127,7 +127,6 @@ else:
         def createLock(self):
             self.lock = None
 
-
 skipUnless = getattr(unittest, "skipUnless", None)
 if not skipUnless:
     # our stupid skipUnless wrapper for python2.6
@@ -139,9 +138,12 @@ if not skipUnless:
                 @wraps(test)
                 def skip(*args, **kwargs):
                     return
+
                 return skip
+
         return wrapper
 skip_unless = skipUnless
+
 
 def requires_progs(*progs):
     missing = []
@@ -153,7 +155,8 @@ def requires_progs(*progs):
 
     friendly_missing = ", ".join(missing)
     return skipUnless(len(missing) == 0, "Missing required system programs: %s"
-            % friendly_missing)
+                      % friendly_missing)
+
 
 requires_posix = skipUnless(os.name == "posix", "Requires POSIX")
 requires_utf8 = skipUnless(sh.DEFAULT_ENCODING == "UTF-8", "System encoding must be UTF-8")
@@ -231,7 +234,6 @@ class FunctionalTests(BaseTests):
         out = str(ls)
         self.assertEqual(out, actual_location)
 
-
     def test_unicode_arg(self):
         from sh import echo
 
@@ -251,7 +253,6 @@ class FunctionalTests(BaseTests):
         native_arg = arg
         if not IS_PY3:
             arg = arg.decode("utf8")
-
 
         try:
             python(py.name, arg, _encoding="utf8")
@@ -342,9 +343,8 @@ exit(3)
             list(out)
             self.assertEqual(out.exit_code, 3)
             self.fail("Command exited with error, but no exception thrown")
-        except ErrorReturnCode as e:
+        except ErrorReturnCode:
             pass
-
 
     def test_exit_code_from_exception(self):
         from sh import ErrorReturnCode
@@ -359,11 +359,10 @@ exit(3)
         except Exception as e:
             self.assertEqual(e.exit_code, 3)
 
-
     def test_stdin_from_string(self):
         from sh import sed
         self.assertEqual(sed(_in="one test three", e="s/test/two/").strip(),
-                "one two three")
+                         "one two three")
 
     def test_ok_code(self):
         from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
@@ -383,7 +382,6 @@ exit(3)
         py = create_tmp_test("exit(0)")
         python(py.name, _ok_code=None)
 
-
     def test_none_arg(self):
         py = create_tmp_test("""
 import sys
@@ -396,7 +394,6 @@ print(sys.argv[1:])
         maybe_arg = None
         out = python(py.name, maybe_arg).strip()
         self.assertEqual(out, "[]")
-
 
     def test_quote_escaping(self):
         py = create_tmp_test("""
@@ -464,9 +461,9 @@ while True:
         derp = Derp()
 
         p = inc(
+            inc(
                 inc(
-                    inc(
-                        python("-u", py.name, _piped=True),
+                    python("-u", py.name, _piped=True),
                     _piped=True),
                 _piped=True),
             _out=derp.agg)
@@ -474,7 +471,6 @@ while True:
         p.wait()
         self.assertEqual("".join(derp.stdout), "dqguhz")
         self.assertTrue(all([t > .15 for t in derp.times]))
-
 
     def test_manual_stdin_string(self):
         from sh import tr
@@ -491,7 +487,6 @@ while True:
         match = "".join([t.upper() for t in test])
         self.assertEqual(out, match)
 
-
     def test_manual_stdin_file(self):
         from sh import tr
         import tempfile
@@ -507,23 +502,24 @@ while True:
 
         self.assertEqual(out, test_string.upper())
 
-
     def test_manual_stdin_queue(self):
         from sh import tr
-        try: from Queue import Queue, Empty
-        except ImportError: from queue import Queue, Empty
+        try:
+            from Queue import Queue
+        except ImportError:
+            from queue import Queue
 
         test = ["testing\n", "herp\n", "derp\n"]
 
         q = Queue()
-        for t in test: q.put(t)
-        q.put(None) # EOF
+        for t in test:
+            q.put(t)
+        q.put(None)  # EOF
 
         out = tr("[:lower:]", "[:upper:]", _in=q)
 
         match = "".join([t.upper() for t in test])
         self.assertEqual(out, match)
-
 
     def test_environment(self):
         """ tests that environments variables that we pass into sh commands
@@ -563,12 +559,10 @@ print(dict(HERP=sh.HERP))
         out = python(py.name, _env=os.environ, _cwd=THIS_DIR).strip()
         self.assertEqual(out, "{'HERP': 'DERP'}")
 
-
     def test_which(self):
         from sh import which, ls
         self.assertEqual(which("fjoawjefojawe"), None)
         self.assertEqual(which("ls"), str(ls))
-
 
     def test_which_paths(self):
         from sh import which
@@ -595,7 +589,6 @@ print("hi")
             flags = fcntl.fcntl(t.fileno(), fcntl.F_GETFD)
             flags &= ~fcntl.FD_CLOEXEC
             fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags)
-        first_fd = tmp[0].fileno()
 
         py = create_tmp_test("""
 import os
@@ -630,7 +623,6 @@ print(os.listdir("/dev/fd"))
 
         for t in tmp:
             t.close()
-
 
     def test_pass_fds(self):
         # guarantee some extra fds in our parent process that don't close on exec.  we have to explicitly do this
@@ -668,7 +660,6 @@ print(os.listdir("/dev/fd"))
         from sh import ls
         self.assertRaises(TypeError, ls, _iter=True, _piped=True)
 
-
     def test_invalid_env(self):
         from sh import ls
 
@@ -687,7 +678,6 @@ print(os.listdir("/dev/fd"))
 exit(2)
 """)
         self.assertRaises(ErrorReturnCode_2, python, py.name)
-
 
     def test_piped_exception1(self):
         from sh import ErrorReturnCode_2
@@ -723,29 +713,30 @@ exit(2)
 
         self.assertRaises(ErrorReturnCode_2, fn)
 
-
     def test_command_not_found(self):
         from sh import CommandNotFound
 
-        def do_import(): from sh import aowjgoawjoeijaowjellll
+        def do_import():
+            from sh import aowjgoawjoeijaowjellll  # noqa: F401
+
         self.assertRaises(ImportError, do_import)
 
         def do_import():
             import sh
             sh.awoefaowejfw
+
         self.assertRaises(CommandNotFound, do_import)
 
         def do_import():
             import sh
             sh.Command("ofajweofjawoe")
-        self.assertRaises(CommandNotFound, do_import)
 
+        self.assertRaises(CommandNotFound, do_import)
 
     def test_command_wrapper_equivalence(self):
         from sh import Command, ls, which
 
         self.assertEqual(Command(which("ls")), ls)
-
 
     def test_doesnt_execute_directories(self):
         save_path = os.environ['PATH']
@@ -768,11 +759,11 @@ exit(2)
             from sh import gcc
             if IS_PY3:
                 self.assertEqual(gcc._path,
-                        gcc_file2.encode(sh.DEFAULT_ENCODING))
+                                 gcc_file2.encode(sh.DEFAULT_ENCODING))
             else:
                 self.assertEqual(gcc._path, gcc_file2)
             self.assertEqual(gcc('no-error').stdout.strip(),
-                'no-error'.encode("ascii"))
+                             'no-error'.encode("ascii"))
 
         finally:
             os.environ['PATH'] = save_path
@@ -793,12 +784,11 @@ parser.add_option("-l", dest="long_option")
 options, args = parser.parse_args()
 print(len(options.long_option.split()))
 """)
-        num_args = int(python(py.name, l="one two three"))
+        num_args = int(python(py.name, l="one two three"))  # noqa: E741
         self.assertEqual(num_args, 3)
 
         num_args = int(python(py.name, "-l", "one's two's three's"))
         self.assertEqual(num_args, 3)
-
 
     def test_multiple_args_long_option(self):
         py = create_tmp_test("""
@@ -809,12 +799,11 @@ options, args = parser.parse_args()
 print(len(options.long_option.split()))
 """)
         num_args = int(python(py.name, long_option="one two three",
-            nothing=False))
+                              nothing=False))
         self.assertEqual(num_args, 3)
 
         num_args = int(python(py.name, "--long-option", "one's two's three's"))
         self.assertEqual(num_args, 3)
-
 
     def test_short_bool_option(self):
         py = create_tmp_test("""
@@ -828,7 +817,6 @@ print(options.short_option)
         self.assertTrue(python(py.name, s=False).strip() == "False")
         self.assertTrue(python(py.name).strip() == "False")
 
-
     def test_long_bool_option(self):
         py = create_tmp_test("""
 from optparse import OptionParser
@@ -840,7 +828,6 @@ print(options.long_option)
         self.assertTrue(python(py.name, long_option=True).strip() == "True")
         self.assertTrue(python(py.name).strip() == "False")
 
-
     def test_false_bool_ignore(self):
         py = create_tmp_test("""
 import sys
@@ -851,26 +838,23 @@ print(sys.argv[1:])
         test = False
         self.assertEqual(python(py.name, test and "-n").strip(), "[]")
 
-
     def test_composition(self):
         from sh import ls, wc
-        c1 = int(wc(ls("-A1"), l=True))
+        c1 = int(wc(ls("-A1"), l=True))  # noqa: E741
         c2 = len(os.listdir("."))
         self.assertEqual(c1, c2)
 
     def test_incremental_composition(self):
         from sh import ls, wc
-        c1 = int(wc(ls("-A1", _piped=True), l=True).strip())
+        c1 = int(wc(ls("-A1", _piped=True), l=True).strip())  # noqa: E741
         c2 = len(os.listdir("."))
         self.assertEqual(c1, c2)
-
 
     def test_short_option(self):
         from sh import sh
         s1 = sh(c="echo test").strip()
         s2 = "test"
         self.assertEqual(s1, s2)
-
 
     def test_long_option(self):
         py = create_tmp_test("""
@@ -899,7 +883,7 @@ else:
     print(options.long_option2.upper())
 """)
         self.assertEqual(python(py.name,
-            {"long_option": "underscore"}).strip(), "UNDERSCORE")
+                                {"long_option": "underscore"}).strip(), "UNDERSCORE")
 
         self.assertEqual(python(py.name, long_option="hyphen").strip(), "HYPHEN")
 
@@ -921,7 +905,6 @@ print(sys.argv[1])
         out = python_baked().strip()
         self.assertEqual(out, correct)
 
-
     def test_custom_separator_space(self):
         py = create_tmp_test("""
 import sys
@@ -932,7 +915,6 @@ print(str(sys.argv[1:]))
         out = python(py.name, opt, _long_sep=" ").strip()
         self.assertEqual(out, str(correct))
 
-
     def test_custom_long_prefix(self):
         py = create_tmp_test("""
 import sys
@@ -940,22 +922,21 @@ print(sys.argv[1])
 """)
 
         out = python(py.name, {"long-option": "underscore"},
-                _long_prefix="-custom-").strip()
+                     _long_prefix="-custom-").strip()
         self.assertEqual(out, "-custom-long-option=underscore")
 
         out = python(py.name, {"long-option": True},
-                _long_prefix="-custom-").strip()
+                     _long_prefix="-custom-").strip()
         self.assertEqual(out, "-custom-long-option")
 
         # test baking too
         out = python.bake(py.name, {"long-option": "underscore"},
-                _long_prefix="-baked-")().strip()
+                          _long_prefix="-baked-")().strip()
         self.assertEqual(out, "-baked-long-option=underscore")
 
         out = python.bake(py.name, {"long-option": True},
-                _long_prefix="-baked-")().strip()
+                          _long_prefix="-baked-")().strip()
         self.assertEqual(out, "-baked-long-option")
-
 
     def test_command_wrapper(self):
         from sh import Command, which
@@ -963,11 +944,10 @@ print(sys.argv[1])
         ls = Command(which("ls"))
         wc = Command(which("wc"))
 
-        c1 = int(wc(ls("-A1"), l=True))
+        c1 = int(wc(ls("-A1"), l=True))  # noqa: E741
         c2 = len(os.listdir("."))
 
         self.assertEqual(c1, c2)
-
 
     def test_background(self):
         from sh import sleep
@@ -984,15 +964,14 @@ print(sys.argv[1])
         now = time.time()
         self.assertGreater(now - start, sleep_time)
 
-
     def test_background_exception(self):
         from sh import ls, ErrorReturnCode_1, ErrorReturnCode_2
-        p = ls("/ofawjeofj", _bg=True, _bg_exc=False) # should not raise
+        p = ls("/ofawjeofj", _bg=True, _bg_exc=False)  # should not raise
 
         exc_to_test = ErrorReturnCode_2
-        if IS_MACOS: exc_to_test = ErrorReturnCode_1
-        self.assertRaises(exc_to_test, p.wait) # should raise
-
+        if IS_MACOS:
+            exc_to_test = ErrorReturnCode_1
+        self.assertRaises(exc_to_test, p.wait)  # should raise
 
     def test_with_context(self):
         from sh import whoami
@@ -1012,7 +991,6 @@ subprocess.Popen(sys.argv[1:], shell=False).wait()
             out = whoami()
         self.assertIn("with_context", out)
         self.assertIn(getpass.getuser(), out)
-
 
     def test_with_context_args(self):
         from sh import whoami
@@ -1035,11 +1013,9 @@ if options.opt:
             out = whoami()
         self.assertTrue(getpass.getuser() == out.strip())
 
-
         with python(py.name, _with=True):
             out = whoami()
         self.assertTrue(out == "")
-
 
     def test_binary_input(self):
         py = create_tmp_test("""
@@ -1050,7 +1026,6 @@ sys.stdout.write(data)
         data = b'1234'
         out = python(py.name, _in=data)
         self.assertEqual(out, "1234")
-
 
     def test_err_to_out(self):
         py = create_tmp_test("""
@@ -1080,7 +1055,6 @@ sys.stderr.flush()
         self.assertEqual(stdout, "")
         self.assertEqual(os.read(master, 12), b"stdoutstderr")
 
-
     def test_err_piped(self):
         py = create_tmp_test("""
 import sys
@@ -1098,8 +1072,6 @@ while True:
 
         out = python(python("-u", py.name, _piped="err"), "-u", py2.name)
         self.assertEqual(out, "stderr")
-
-
 
     def test_out_redirection(self):
         import tempfile
@@ -1123,7 +1095,6 @@ sys.stderr.write("stderr")
 
         self.assertNotEqual(len(actual_out), 0)
 
-
         # test with tee
         file_obj = tempfile.NamedTemporaryFile()
         out = python(py.name, _out=file_obj, _tee=True)
@@ -1135,8 +1106,6 @@ sys.stderr.write("stderr")
         file_obj.close()
 
         self.assertGreater(len(actual_out), 0)
-
-
 
     def test_err_redirection(self):
         import tempfile
@@ -1171,7 +1140,6 @@ sys.stderr.write("stderr")
         self.assertEqual(stderr, "stderr")
         self.assertGreater(len(p.stderr), 0)
 
-
     def test_tty_tee(self):
         py = create_tmp_test("""
 import sys
@@ -1195,26 +1163,24 @@ sys.stdout.write("stdout")
         os.close(write)
         os.close(read)
 
-
     def test_err_redirection_actual_file(self):
-      import tempfile
-      file_obj = tempfile.NamedTemporaryFile()
-      py = create_tmp_test("""
+        import tempfile
+        file_obj = tempfile.NamedTemporaryFile()
+        py = create_tmp_test("""
 import sys
 import os
 
 sys.stdout.write("stdout")
 sys.stderr.write("stderr")
 """)
-      stdout = python("-u", py.name, _err=file_obj.name).wait()
-      file_obj.seek(0)
-      stderr = file_obj.read().decode()
-      file_obj.close()
-      self.assertTrue(stdout == "stdout")
-      self.assertTrue(stderr == "stderr")
+        stdout = python("-u", py.name, _err=file_obj.name).wait()
+        file_obj.seek(0)
+        stderr = file_obj.read().decode()
+        file_obj.close()
+        self.assertTrue(stdout == "stdout")
+        self.assertTrue(stderr == "stderr")
 
     def test_subcommand_and_bake(self):
-        from sh import ls
         import getpass
 
         py = create_tmp_test("""
@@ -1231,7 +1197,6 @@ subprocess.Popen(sys.argv[1:], shell=False).wait()
         self.assertIn("subcommand", out)
         self.assertIn(getpass.getuser(), out)
 
-
     def test_multiple_bakes(self):
         py = create_tmp_test("""
 import sys
@@ -1246,6 +1211,7 @@ sys.stdout.write(str(sys.argv[1:]))
 import sys
 sys.stdout.write(str(sys.argv[1:]))
 """)
+
         def arg_preprocess(args, kwargs):
             args.insert(0, "preprocessed")
             kwargs["a-kwarg"] = 123
@@ -1271,7 +1237,6 @@ sys.stdout.write(str(sys.argv[1:]))
 
         self.assertEqual(iam1, iam2)
 
-
     # https://github.com/amoffat/sh/pull/252
     def test_stdout_pipe(self):
         py = create_tmp_test(r"""
@@ -1281,7 +1246,7 @@ sys.stdout.write("foobar\n")
 """)
 
         read_fd, write_fd = os.pipe()
-        p = python(py.name, _out=write_fd, u=True)
+        python(py.name, _out=write_fd, u=True)
 
         def alarm(sig, action):
             self.fail("Timeout while reading from pipe")
@@ -1295,7 +1260,6 @@ sys.stdout.write("foobar\n")
         signal.alarm(0)
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
-
     def test_stdout_callback(self):
         py = create_tmp_test("""
 import sys
@@ -1304,6 +1268,7 @@ import os
 for i in range(5): print(i)
 """)
         stdout = []
+
         def agg(line):
             stdout.append(line)
 
@@ -1311,8 +1276,6 @@ for i in range(5): print(i)
         p.wait()
 
         self.assertEqual(len(stdout), 5)
-
-
 
     def test_stdout_callback_no_wait(self):
         import time
@@ -1328,17 +1291,16 @@ for i in range(5):
 """)
 
         stdout = []
+
         def agg(line): stdout.append(line)
 
-        p = python("-u", py.name, _out=agg, _bg=True)
+        python("-u", py.name, _out=agg, _bg=True)
 
         # we give a little pause to make sure that the NamedTemporaryFile
         # exists when the python process actually starts
         time.sleep(.5)
 
         self.assertNotEqual(len(stdout), 5)
-
-
 
     def test_stdout_callback_line_buffered(self):
         py = create_tmp_test("""
@@ -1349,14 +1311,13 @@ for i in range(5): print("herpderp")
 """)
 
         stdout = []
+
         def agg(line): stdout.append(line)
 
         p = python("-u", py.name, _out=agg, _out_bufsize=1)
         p.wait()
 
         self.assertEqual(len(stdout), 5)
-
-
 
     def test_stdout_callback_line_unbuffered(self):
         py = create_tmp_test("""
@@ -1367,6 +1328,7 @@ for i in range(5): print("herpderp")
 """)
 
         stdout = []
+
         def agg(char): stdout.append(char)
 
         p = python("-u", py.name, _out=agg, _out_bufsize=0)
@@ -1374,7 +1336,6 @@ for i in range(5): print("herpderp")
 
         # + 5 newlines
         self.assertEqual(len(stdout), len("herpderp") * 5 + 5)
-
 
     def test_stdout_callback_buffered(self):
         py = create_tmp_test("""
@@ -1385,14 +1346,13 @@ for i in range(5): sys.stdout.write("herpderp")
 """)
 
         stdout = []
+
         def agg(chunk): stdout.append(chunk)
 
         p = python("-u", py.name, _out=agg, _out_bufsize=4)
         p.wait()
 
         self.assertEqual(len(stdout), len("herp") / 2 * 5)
-
-
 
     def test_stdout_callback_with_input(self):
         py = create_tmp_test("""
@@ -1407,14 +1367,13 @@ print(derp)
 """)
 
         def agg(line, stdin):
-            if line.strip() == "4": stdin.put("derp\n")
+            if line.strip() == "4":
+                stdin.put("derp\n")
 
         p = python("-u", py.name, _out=agg, _tee=True)
         p.wait()
 
         self.assertIn("derp", p)
-
-
 
     def test_stdout_callback_exit(self):
         py = create_tmp_test("""
@@ -1425,18 +1384,18 @@ for i in range(5): print(i)
 """)
 
         stdout = []
+
         def agg(line):
             line = line.strip()
             stdout.append(line)
-            if line == "2": return True
+            if line == "2":
+                return True
 
         p = python("-u", py.name, _out=agg, _tee=True)
         p.wait()
 
         self.assertIn("4", p)
         self.assertNotIn("4", stdout)
-
-
 
     def test_stdout_callback_terminate(self):
         import signal
@@ -1451,6 +1410,7 @@ for i in range(5):
 """)
 
         stdout = []
+
         def agg(line, stdin, process):
             line = line.strip()
             stdout.append(line)
@@ -1471,8 +1431,6 @@ for i in range(5):
         self.assertNotIn("4", p)
         self.assertNotIn("4", stdout)
 
-
-
     def test_stdout_callback_kill(self):
         import signal
 
@@ -1487,6 +1445,7 @@ for i in range(5):
 """)
 
         stdout = []
+
         def agg(line, stdin, process):
             line = line.strip()
             stdout.append(line)
@@ -1508,7 +1467,6 @@ for i in range(5):
         self.assertNotIn("4", stdout)
 
     def test_general_signal(self):
-        import signal
         from signal import SIGINT
 
         py = create_tmp_test("""
@@ -1530,6 +1488,7 @@ for i in range(5):
 """)
 
         stdout = []
+
         def agg(line, stdin, process):
             line = line.strip()
             stdout.append(line)
@@ -1542,7 +1501,6 @@ for i in range(5):
 
         self.assertEqual(p.process.exit_code, 0)
         self.assertEqual(p, "0\n1\n2\n3\n10\n")
-
 
     def test_iter_generator(self):
         py = create_tmp_test("""
@@ -1563,7 +1521,7 @@ for i in range(42):
 
     def test_iter_unicode(self):
         # issue https://github.com/amoffat/sh/issues/224
-        test_string = "\xe4\xbd\x95\xe4\xbd\x95\n" * 150 # len > buffer_s
+        test_string = "\xe4\xbd\x95\xe4\xbd\x95\n" * 150  # len > buffer_s
         txt = create_tmp_test(test_string)
         for line in sh.cat(txt.name, _iter=True):
             break
@@ -1605,9 +1563,6 @@ sys.stderr.write("stderr")
         self.assertGreater(count, 0)
         self.assertEqual(value, "stderr")
 
-
-
-
     def test_for_generator_to_err(self):
         py = create_tmp_test("""
 import sys
@@ -1628,10 +1583,7 @@ for i in range(42):
             out.append(line)
         self.assertEqual(len(out), 0)
 
-
     def test_sigpipe(self):
-        import sh
-
         py1 = create_tmp_test("""
 import sys
 import os
@@ -1669,10 +1621,7 @@ while True:
         self.assertEqual(-p1.exit_code, signal.SIGPIPE)
         self.assertEqual(p2.exit_code, 0)
 
-
     def test_piped_generator(self):
-        from sh import tr
-        from string import ascii_uppercase
         import time
 
         py1 = create_tmp_test("""
@@ -1697,24 +1646,21 @@ while True:
     print(line.strip().upper())
         """)
 
-
         times = []
         last_received = None
 
         letters = ""
         for line in python(python("-u", py1.name, _piped="out"), "-u",
-                py2.name, _iter=True):
-            if not letters:
-                start = time.time()
+                           py2.name, _iter=True):
             letters += line.strip()
 
             now = time.time()
-            if last_received: times.append(now - last_received)
+            if last_received:
+                times.append(now - last_received)
             last_received = now
 
         self.assertEqual("ANDREW", letters)
         self.assertTrue(all([t > .3 for t in times]))
-
 
     def test_generator_and_callback(self):
         py = create_tmp_test("""
@@ -1727,14 +1673,16 @@ for i in range(42):
 """)
 
         stderr = []
-        def agg(line): stderr.append(int(line.strip()))
+
+        def agg(line):
+            stderr.append(int(line.strip()))
 
         out = []
-        for line in python("-u", py.name, _iter=True, _err=agg): out.append(line)
+        for line in python("-u", py.name, _iter=True, _err=agg):
+            out.append(line)
 
         self.assertEqual(len(out), 42)
         self.assertEqual(sum(stderr), 1722)
-
 
     def test_cast_bg(self):
         py = create_tmp_test("""
@@ -1787,7 +1735,7 @@ exit(code)
         env = os.environ.copy()
         env["EXIT"] = "3"
         self.assertRaises(sh.ErrorReturnCode_3, python, py.name, _fg=True,
-                _env=env)
+                          _env=env)
 
     def test_fg_alternative(self):
         py = create_tmp_test("exit(0)")
@@ -1819,7 +1767,6 @@ exit(49)
         self.assertEqual(str(pwd(_cwd="/tmp")), realpath("/tmp") + "\n")
         self.assertEqual(str(pwd(_cwd="/etc")), realpath("/etc") + "\n")
 
-
     def test_cwd_fg(self):
         td = realpath(tempfile.mkdtemp())
         py = create_tmp_test("""
@@ -1839,7 +1786,6 @@ print(realpath(os.getcwd()))
         self.assertNotEqual(orig, newdir)
         os.rmdir(td)
 
-
     def test_huge_piped_data(self):
         from sh import tr
 
@@ -1852,7 +1798,6 @@ print(realpath(os.getcwd()))
 
         out = tr(tr("[:lower:]", "[:upper:]", _in=data), "[:upper:]", "[:lower:]")
         self.assertTrue(out == data)
-
 
     def test_tty_input(self):
         py = create_tmp_test("""
@@ -1876,7 +1821,8 @@ else:
 
         def password_enterer(line, stdin):
             line = line.strip()
-            if not line: return
+            if not line:
+                return
 
             if line == "password?":
                 stdin.put(test_pw + "\n")
@@ -1891,7 +1837,6 @@ else:
 
         response = python(py.name)
         self.assertEqual(response, "no tty attached!\n")
-
 
     def test_tty_output(self):
         py = create_tmp_test("""
@@ -1912,7 +1857,6 @@ else:
         out = python(py.name, _tty_out=False)
         self.assertEqual(out, "no tty attached")
 
-
     def test_stringio_output(self):
         from sh import echo
 
@@ -1932,7 +1876,6 @@ else:
         echo("-n", "testing 123", _out=out)
         self.assertEqual(out.getvalue().decode(), "testing 123")
 
-
     def test_stringio_input(self):
         from sh import cat
 
@@ -1943,16 +1886,14 @@ else:
         out = cat(_in=input)
         self.assertEqual(out, "herpderp")
 
-
     def test_internal_bufsize(self):
         from sh import cat
 
-        output = cat(_in="a"*1000, _internal_bufsize=100, _out_bufsize=0)
+        output = cat(_in="a" * 1000, _internal_bufsize=100, _out_bufsize=0)
         self.assertEqual(len(output), 100)
 
-        output = cat(_in="a"*1000, _internal_bufsize=50, _out_bufsize=2)
+        output = cat(_in="a" * 1000, _internal_bufsize=50, _out_bufsize=2)
         self.assertEqual(len(output), 100)
-
 
     def test_change_stdout_buffering(self):
         py = create_tmp_test("""
@@ -1980,9 +1921,11 @@ sys.stdin.read(1)
             "newline_buffer_success": False,
             "unbuffered_success": False,
         }
+
         def interact(line, stdin, process):
             line = line.strip()
-            if not line: return
+            if not line:
+                return
 
             if line == "switch buffering":
                 d["newline_buffer_success"] = True
@@ -2001,7 +1944,6 @@ sys.stdin.read(1)
         self.assertTrue(d["newline_buffer_success"])
         self.assertTrue(d["unbuffered_success"])
 
-
     def test_callable_interact(self):
         py = create_tmp_test("""
 import sys
@@ -2011,6 +1953,7 @@ sys.stdout.write("line1")
         class Callable(object):
             def __init__(self):
                 self.line = None
+
             def __call__(self, line):
                 self.line = line
 
@@ -2018,12 +1961,8 @@ sys.stdout.write("line1")
         python(py.name, _out=cb)
         self.assertEqual(cb.line, "line1")
 
-
     def test_encoding(self):
-        return
-        raise NotImplementedError("what's the best way to test a different \
-'_encoding' special keyword argument?")
-
+        return self.skipTest("what's the best way to test a different '_encoding' special keyword argument?")
 
     def test_timeout(self):
         import sh
@@ -2041,31 +1980,23 @@ sys.stdout.write("line1")
         elapsed = time() - started
         self.assertLess(abs(elapsed - timeout), 0.5)
 
-
     def test_timeout_overstep(self):
         started = time.time()
         sh.sleep(1, _timeout=5)
         elapsed = time.time() - started
         self.assertLess(abs(elapsed - 1), 0.5)
 
-
     def test_timeout_wait(self):
-        started = time.time()
         p = sh.sleep(3, _bg=True)
         self.assertRaises(sh.TimeoutException, p.wait, timeout=1)
 
-
     def test_timeout_wait_overstep(self):
-        started = time.time()
         p = sh.sleep(1, _bg=True)
         p.wait(timeout=5)
 
-
     def test_timeout_wait_negative(self):
-        started = time.time()
         p = sh.sleep(3, _bg=True)
         self.assertRaises(RuntimeError, p.wait, timeout=-3)
-
 
     def test_binary_pipe(self):
         binary = b'\xec;\xedr\xdbF'
@@ -2088,7 +2019,6 @@ sys.stdout.write(sys.stdin.read())
 """)
         out = python(python(py1.name), py2.name)
         self.assertEqual(out.stdout, binary)
-
 
     # designed to trigger the "... (%d more, please see e.stdout)" output
     # of the ErrorReturnCode class
@@ -2116,7 +2046,6 @@ exit(1)
 
         self.assertRaises(ErrorReturnCode, ls, test)
 
-
     def test_no_out(self):
         py = create_tmp_test("""
 import sys
@@ -2129,6 +2058,7 @@ sys.stderr.write("stderr")
         self.assertTrue(p.process._pipe_queue.empty())
 
         def callback(line): pass
+
         p = python(py.name, _out=callback)
         self.assertEqual(p.stdout, b"")
         self.assertEqual(p.stderr, b"stderr")
@@ -2139,7 +2069,6 @@ sys.stderr.write("stderr")
         self.assertEqual(p.stderr, b"stderr")
         self.assertFalse(p.process._pipe_queue.empty())
 
-
     def test_tty_stdin(self):
         py = create_tmp_test("""
 import sys
@@ -2148,7 +2077,6 @@ sys.stdout.flush()
 """)
         out = python(py.name, _in="test\n", _tty_in=True)
         self.assertEqual("test\n", out)
-
 
     def test_no_err(self):
         py = create_tmp_test("""
@@ -2162,6 +2090,7 @@ sys.stderr.write("stderr")
         self.assertFalse(p.process._pipe_queue.empty())
 
         def callback(line): pass
+
         p = python(py.name, _err=callback)
         self.assertEqual(p.stderr, b"")
         self.assertEqual(p.stdout, b"stdout")
@@ -2172,7 +2101,6 @@ sys.stderr.write("stderr")
         self.assertEqual(p.stdout, b"stdout")
         self.assertFalse(p.process._pipe_queue.empty())
 
-
     def test_no_pipe(self):
         from sh import ls
 
@@ -2182,13 +2110,13 @@ sys.stderr.write("stderr")
 
         # calling a command with a callback should not
         def callback(line): pass
+
         p = ls(_out=callback)
         self.assertTrue(p.process._pipe_queue.empty())
 
         # calling a command regular with no_pipe also should not
         p = ls(_no_pipe=True)
         self.assertTrue(p.process._pipe_queue.empty())
-
 
     def test_decode_error_handling(self):
         from functools import partial
@@ -2205,12 +2133,13 @@ else:
     sys.stdout.write("te漢字st")
 """)
         fn = partial(python, py.name, _encoding="ascii")
+
         def s(fn): str(fn())
+
         self.assertRaises(UnicodeDecodeError, s, fn)
 
         p = python(py.name, _encoding="ascii", _decode_errors="ignore")
         self.assertEqual(p, "test")
-
 
     def test_signal_exception(self):
         from sh import SignalException_15
@@ -2225,7 +2154,6 @@ while True: time.sleep(1)
             to_kill.wait()
 
         self.assertRaises(SignalException_15, throw_terminate_signal)
-
 
     def test_signal_group(self):
         child = create_tmp_test("""
@@ -2258,7 +2186,6 @@ p.wait()
         def assert_dead(pid):
             self.assert_oserror(errno.ESRCH, os.kill, pid, 0)
 
-
         # first let's prove that calling regular SIGKILL on the parent does
         # nothing to the child, since the child was launched in the same process
         # group (_new_session=False) and the parent is not a controlling process
@@ -2275,7 +2202,6 @@ p.wait()
         self.assertRaises(sh.SignalException_SIGKILL, p.wait)
         assert_dead(child_pid)
 
-
         # now let's prove that killing the process group kills both the parent
         # and the child
         p, child_pid, child_pgid, parent_pid, parent_pgid = launch()
@@ -2287,7 +2213,6 @@ p.wait()
         time.sleep(0.1)
         assert_dead(parent_pid)
         assert_dead(child_pid)
-
 
     def test_pushd(self):
         """ test basic pushd functionality """
@@ -2309,12 +2234,9 @@ p.wait()
         self.assertEqual(new_wd1, tempdir)
         self.assertEqual(new_wd2, tempdir)
 
-
-
     def test_pushd_cd(self):
         """ test that pushd works like pushd/popd with built-in cd correctly """
         import sh
-        from sh import mkdir
 
         child = realpath(tempfile.mkdtemp())
         try:
@@ -2344,14 +2266,12 @@ p.wait()
         self.assertFalse(exists(non_exist_dir))
         self.assertRaises(sh.ForkException, ls, _cwd=non_exist_dir)
 
-
     # https://github.com/amoffat/sh/issues/176
     def test_baked_command_can_be_printed(self):
         from sh import ls
 
         ll = ls.bake("-l")
         self.assertTrue(str(ll).endswith("/ls -l"))
-
 
     # https://github.com/amoffat/sh/issues/185
     def test_done_callback(self):
@@ -2388,16 +2308,15 @@ print(time())
         self.assertEqual(callback.exit_code, 0)
         self.assertTrue(callback.success)
 
-
     def test_fork_exc(self):
         from sh import ForkException
 
         py = create_tmp_test("")
+
         def fail():
             raise RuntimeError("nooo")
 
         self.assertRaises(ForkException, python, py.name, _preexec_fn=fail)
-
 
     def test_new_session(self):
         from threading import Event
@@ -2413,7 +2332,6 @@ stuff = [pid, pgid, sid]
 print(",".join([str(el) for el in stuff]))
 time.sleep(0.5)
 """)
-
 
         event = Event()
 
@@ -2439,9 +2357,7 @@ time.sleep(0.5)
         p.wait()
         self.assertTrue(event.is_set())
 
-
         event.clear()
-
 
         def handle(line, stdin, p):
             pid, pgid, sid = line.strip().split(",")
@@ -2467,8 +2383,6 @@ time.sleep(0.5)
         p.wait()
         self.assertTrue(event.is_set())
 
-
-
     def test_done_cb_exc(self):
         from sh import ErrorReturnCode
 
@@ -2476,6 +2390,7 @@ time.sleep(0.5)
             def __init__(self):
                 self.called = False
                 self.success = None
+
             def __call__(self, p, success, exit_code):
                 self.success = success
                 self.called = True
@@ -2514,7 +2429,6 @@ sys.stdout.write(sys.stdin.read())
         self.assertEqual("0123", out)
 
     def test_stdin_unbuffered_bufsize(self):
-        import sh
         from time import sleep
 
         # this tries to receive some known data and measures the time it takes
@@ -2546,19 +2460,16 @@ sys.stdout.flush()
             sleep(1)
             yield "done"
 
-
         out = python(py.name, _in=create_stdin(), _in_bufsize=0)
         word1, time1, word2, time2, _ = out.split("\n")
         time1 = float(time1)
         time2 = float(time2)
         self.assertEqual(word1, "testing")
-        self.assertLess(abs(1-time1), 0.5)
+        self.assertLess(abs(1 - time1), 0.5)
         self.assertEqual(word2, "done")
-        self.assertLess(abs(1-time2), 0.5)
-
+        self.assertLess(abs(1 - time2), 0.5)
 
     def test_stdin_newline_bufsize(self):
-        import sh
         from time import sleep
 
         # this tries to receive some known data and measures the time it takes
@@ -2593,16 +2504,14 @@ sys.stdout.flush()
             sleep(1)
             yield "done\n"
 
-
         out = python(py.name, _in=create_stdin(), _in_bufsize=1)
         word1, time1, word2, time2, _ = out.split("\n")
         time1 = float(time1)
         time2 = float(time2)
         self.assertEqual(word1, "testing")
-        self.assertLess(abs(1-time1), 0.5)
+        self.assertLess(abs(1 - time1), 0.5)
         self.assertEqual(word2, "done")
-        self.assertLess(abs(1-time2), 0.5)
-
+        self.assertLess(abs(1 - time2), 0.5)
 
     def test_custom_timeout_signal(self):
         from sh import TimeoutException
@@ -2618,7 +2527,6 @@ time.sleep(3)
             self.assertEqual(e.exit_code, signal.SIGQUIT)
         else:
             self.fail("we should have handled a TimeoutException")
-
 
     def test_append_stdout(self):
         py = create_tmp_test("""
@@ -2641,7 +2549,6 @@ sys.stdout.write(sys.argv[1])
         out = python.bake(py.name).bake_()
         self.assertEqual("bake", out)
 
-
     def test_no_proc_no_attr(self):
         py = create_tmp_test("")
         with python(py.name) as p:
@@ -2656,20 +2563,21 @@ for i in range(10):
 """)
 
         output = []
+
         def fn(foo, line):
             output.append((foo, int(line.strip())))
 
         log_line = partial(fn, "hello")
-        out = python(py.name, _out=log_line)
+        python(py.name, _out=log_line)
         self.assertEqual(output, [("hello", i) for i in range(10)])
 
-
         output = []
+
         def fn(foo, line, stdin, proc):
             output.append((foo, int(line.strip())))
 
         log_line = partial(fn, "hello")
-        out = python(py.name, _out=log_line)
+        python(py.name, _out=log_line)
         self.assertEqual(output, [("hello", i) for i in range(10)])
 
     # https://github.com/amoffat/sh/issues/266
@@ -2714,7 +2622,6 @@ time.sleep(1) # give child a chance to set up
         out = output_file.readlines()[0]
         self.assertEqual(out, b"made it!\n")
 
-
     def test_unchecked_producer_failure(self):
         from sh import ErrorReturnCode_2
 
@@ -2733,7 +2640,6 @@ for line in sys.stdin:
 
         direct_pipe = python(producer.name, _piped=True)
         self.assertRaises(ErrorReturnCode_2, python, direct_pipe, consumer.name)
-
 
     def test_unchecked_pipeline_failure(self):
         # similar to test_unchecked_producer_failure, but this
@@ -2781,7 +2687,6 @@ class MockTests(BaseTests):
         self.assertEqual(test(), "some output")
         self.assertRaises(sh.CommandNotFound, fn)
 
-
     def test_patch_command(self):
         def fn():
             return sh.afowejfow()
@@ -2816,7 +2721,6 @@ exit(1)
         else:
             self.fail("Didn't get an exception")
 
-
     @requires_poller("poll")
     def test_fd_over_1024(self):
         py = create_tmp_test("""print("hi world")""")
@@ -2835,7 +2739,6 @@ exit(1)
                 os.close(master)
                 os.close(slave)
 
-
     def test_args_deprecated(self):
         self.assertRaises(DeprecationWarning, sh.args, _env={})
 
@@ -2845,9 +2748,9 @@ exit(1)
         py = create_tmp_test("""
 print("cool")
 """)
-        out = python(py.name, "%")
-        out = python(py.name, "%%")
-        out = python(py.name, "%%%")
+        python(py.name, "%")
+        python(py.name, "%%")
+        python(py.name, "%%%")
 
     # TODO
     # for some reason, i can't get a good stable baseline measured in this test
@@ -2882,10 +2785,11 @@ print("cool")
                     opt_dict[key] = val
                 yield opt_dict
 
-
         test_pid = os.getpid()
+
         def get_num_fds():
             lines = sh.lsof(p=test_pid).strip().split("\n")
+
             def test(line):
                 line = line.upper()
                 return "CHR" in line or "PIPE" in line
@@ -2894,6 +2798,7 @@ print("cool")
             return len(lines) - 1
 
         py = create_tmp_test("")
+
         def test_command(**opts):
             python(py.name, **opts)
 
@@ -2905,13 +2810,11 @@ print("cool")
             num_fds = get_num_fds()
             self.assertEqual(baseline, num_fds)
 
-
         for opts in get_opts(kwargs):
             for i in xrange(2):
                 test_command(**opts)
                 num_fds = get_num_fds()
                 self.assertEqual(baseline, num_fds, (baseline, num_fds, opts))
-
 
     def test_pushd_thread_safety(self):
         import threading
@@ -2946,7 +2849,6 @@ print("cool")
         finally:
             os.rmdir(temp1)
             os.rmdir(temp2)
-
 
     def test_stdin_nohang(self):
         py = create_tmp_test("""
@@ -2988,7 +2890,6 @@ print("字")
         finally:
             os.unlink(py.name)
 
-
     # https://github.com/amoffat/sh/issues/121
     def test_wraps(self):
         from sh import ls
@@ -3005,7 +2906,6 @@ print("字")
         from sh import SignalException_SIGQUIT
 
         self.assertEqual(sig, SignalException_SIGQUIT)
-
 
     def test_change_log_message(self):
         py = create_tmp_test("""
@@ -3030,13 +2930,10 @@ print("cool")
         self.assertTrue(loglines, "Log handler captured no messages?")
         self.assertTrue(loglines[0].startswith("Hi! I ran something"))
 
-
     # https://github.com/amoffat/sh/issues/273
     def test_stop_iteration_doesnt_block(self):
         """ proves that calling calling next() on a stopped iterator doesn't
         hang. """
-
-        import sh
         py = create_tmp_test("""
 print("cool")
 """)
@@ -3049,7 +2946,6 @@ print("cool")
 
     # https://github.com/amoffat/sh/issues/195
     def test_threaded_with_contexts(self):
-        import sh
         import threading
         import time
 
@@ -3088,12 +2984,12 @@ sys.stdout.write(repr(res))
         ]
         self.assertEqual(results, correct)
 
-
     # https://github.com/amoffat/sh/pull/292
     def test_eintr(self):
         import signal
 
         def handler(num, frame): pass
+
         signal.signal(signal.SIGALRM, handler)
 
         py = create_tmp_test("""
@@ -3105,10 +3001,10 @@ time.sleep(2)
         p.wait()
 
 
-
 class StreamBuffererTests(unittest.TestCase):
     def test_unbuffered(self):
-        from sh import _disable_whitelist, StreamBufferer
+        from sh import _disable_whitelist  # noqa: F401
+        from sh import StreamBufferer
         b = StreamBufferer(0)
 
         self.assertEqual(b.process(b"test"), [b"test"])
@@ -3117,7 +3013,8 @@ class StreamBuffererTests(unittest.TestCase):
         self.assertEqual(b.flush(), b"")
 
     def test_newline_buffered(self):
-        from sh import _disable_whitelist, StreamBufferer
+        from sh import _disable_whitelist  # noqa: F401
+        from sh import StreamBufferer
         b = StreamBufferer(1)
 
         self.assertEqual(b.process(b"testing\none\ntwo"), [b"testing\n", b"one\n"])
@@ -3125,7 +3022,8 @@ class StreamBuffererTests(unittest.TestCase):
         self.assertEqual(b.flush(), b"four")
 
     def test_chunk_buffered(self):
-        from sh import _disable_whitelist, StreamBufferer
+        from sh import _disable_whitelist  # noqa: F401
+        from sh import StreamBufferer
         b = StreamBufferer(10)
 
         self.assertEqual(b.process(b"testing\none\ntwo"), [b"testing\non"])
@@ -3145,7 +3043,7 @@ class ExecutionContextTests(unittest.TestCase):
     def test_no_interfere1(self):
         import sh
         out = StringIO()
-        _sh = sh(_out=out)
+        _sh = sh(_out=out)  # noqa: F841
         from _sh import echo
         echo("-n", "TEST")
         self.assertEqual("TEST", out.getvalue())
@@ -3161,7 +3059,7 @@ class ExecutionContextTests(unittest.TestCase):
         import sh
         out = StringIO()
         from sh import echo
-        _sh = sh(_out=out)
+        _sh = sh(_out=out)  # noqa: F841
         echo("-n", "TEST")
         self.assertEqual("", out.getvalue())
 
@@ -3178,11 +3076,14 @@ class ExecutionContextTests(unittest.TestCase):
         import sh
         out = StringIO()
         _sh = sh(_out=out)
+
         def nested1():
             _sh.echo("-n", "TEST1")
+
         def nested2():
             import sh
             sh.echo("-n", "TEST2")
+
         nested1()
         nested2()
         self.assertEqual("TEST1", out.getvalue())
@@ -3198,13 +3099,14 @@ class ExecutionContextTests(unittest.TestCase):
     def test_importer_detects_module_name(self):
         import sh
         _sh = sh()
-        omg = _sh
-        from omg import cat
+        omg = _sh  # noqa: F841
+        from omg import cat  # noqa: F401
 
     def test_importer_only_works_with_sh(self):
         def unallowed_import():
-            _os = os
-            from _os import path
+            _os = os  # noqa: F841
+            from _os import path  # noqa: F401
+
         self.assertRaises(ImportError, unallowed_import)
 
     def test_reimport_from_cli(self):
@@ -3243,7 +3145,6 @@ if __name__ == "__main__":
     if IS_PY2 and MINOR_VER != 6:
         test_kwargs["failfast"] = True
         test_kwargs["verbosity"] = 2
-
 
     try:
         # if we're running a specific test, we can let unittest framework figure out

--- a/test.py
+++ b/test.py
@@ -594,7 +594,7 @@ print("hi")
         for t in tmp:
             flags = fcntl.fcntl(t.fileno(), fcntl.F_GETFD)
             flags &= ~fcntl.FD_CLOEXEC
-            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags) 
+            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags)
         first_fd = tmp[0].fileno()
 
         py = create_tmp_test("""
@@ -619,7 +619,7 @@ print(len(os.listdir("/dev/fd")))
         for t in tmp:
             flags = fcntl.fcntl(t.fileno(), fcntl.F_GETFD)
             flags &= ~fcntl.FD_CLOEXEC
-            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags) 
+            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags)
 
         py = create_tmp_test("""
 import os
@@ -642,7 +642,7 @@ print(os.listdir("/dev/fd"))
         for t in tmp:
             flags = fcntl.fcntl(t.fileno(), fcntl.F_GETFD)
             flags &= ~fcntl.FD_CLOEXEC
-            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags) 
+            fcntl.fcntl(t.fileno(), fcntl.F_SETFD, flags)
         last_fd = tmp[-1].fileno()
 
         py = create_tmp_test("""
@@ -1762,7 +1762,7 @@ sys.stdout.write(sys.argv[1])
         # `python` has an env baked into it, and we want `_env` to be None for
         # coverage
         system_python(py.name, _fg=True)
-        
+
     def test_fg_false(self):
         """ https://github.com/amoffat/sh/issues/520 """
         py = create_tmp_test("print('hello')")
@@ -1830,7 +1830,7 @@ print(orig)
 sh.pwd(_cwd="{newdir}", _fg=True)
 print(realpath(os.getcwd()))
 """.format(newdir=td))
-        
+
         orig, newdir, restored = python(py.name).strip().split("\n")
         newdir = realpath(newdir)
         self.assertEqual(newdir, td)

--- a/test.py
+++ b/test.py
@@ -218,6 +218,46 @@ class BaseTests(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
+    # python2.6 lacks this
+    def assertIn(self, needle, haystack):
+        s = super(BaseTests, self)
+        if hasattr(s, "assertIn"):
+            s.assertIn(needle, haystack)
+        else:
+            self.assertTrue(needle in haystack)
+
+    # python2.6 lacks this
+    def assertNotIn(self, needle, haystack):
+        s = super(BaseTests, self)
+        if hasattr(s, "assertNotIn"):
+            s.assertNotIn(needle, haystack)
+        else:
+            self.assertTrue(needle not in haystack)
+
+    # python2.6 lacks this
+    def assertLess(self, a, b):
+        s = super(BaseTests, self)
+        if hasattr(s, "assertLess"):
+            s.assertLess(a, b)
+        else:
+            self.assertTrue(a < b)
+
+    # python2.6 lacks this
+    def assertGreater(self, a, b):
+        s = super(BaseTests, self)
+        if hasattr(s, "assertGreater"):
+            s.assertGreater(a, b)
+        else:
+            self.assertTrue(a > b)
+
+    # python2.6 lacks this
+    def skipTest(self, msg):
+        s = super(BaseTests, self)
+        if hasattr(s, "skipTest"):
+            s.skipTest(msg)
+        else:
+            return
+
 
 @requires_posix
 class FunctionalTests(BaseTests):

--- a/test.py
+++ b/test.py
@@ -2330,7 +2330,7 @@ p.wait()
 
     def test_cd_homedir(self):
         orig = os.getcwd()
-        my_dir = os.path.expanduser("~")
+        my_dir = os.path.realpath(os.path.expanduser("~"))  # Use realpath because homedir may be a symlink
         sh.cd()
 
         self.assertNotEqual(orig, os.getcwd())

--- a/test.py
+++ b/test.py
@@ -1121,7 +1121,7 @@ sys.stderr.write("stderr")
         actual_out = file_obj.read()
         file_obj.close()
 
-        self.assertEqual(len(actual_out), 0)
+        self.assertNotEqual(len(actual_out), 0)
 
 
         # test with tee

--- a/test.py
+++ b/test.py
@@ -256,7 +256,7 @@ class FunctionalTests(BaseTests):
         try:
             python(py.name, arg, _encoding="utf8")
         except ErrorReturnCode as e:
-            self.assertTrue(native_arg in str(e))
+            self.assertIn(native_arg, str(e))
         else:
             self.fail("exception wasn't raised")
 
@@ -604,7 +604,7 @@ print(len(os.listdir("/dev/fd")))
         out = python(py.name, _close_fds=False).strip()
         # pick some number greater than 4, since it's hard to know exactly how many fds will be open/inherted in the
         # child
-        self.assertTrue(int(out) > 7)
+        self.assertGreater(int(out), 7)
 
         for t in tmp:
             t.close()
@@ -978,11 +978,11 @@ print(sys.argv[1])
         p = sleep(sleep_time, _bg=True)
 
         now = time.time()
-        self.assertTrue(now - start < sleep_time)
+        self.assertLess(now - start, sleep_time)
 
         p.wait()
         now = time.time()
-        self.assertTrue(now - start > sleep_time)
+        self.assertGreater(now - start, sleep_time)
 
 
     def test_background_exception(self):
@@ -1010,8 +1010,8 @@ subprocess.Popen(sys.argv[1:], shell=False).wait()
         cmd1 = python.bake(py.name, _with=True)
         with cmd1:
             out = whoami()
-        self.assertTrue("with_context" in out)
-        self.assertTrue(getpass.getuser() in out)
+        self.assertIn("with_context", out)
+        self.assertIn(getpass.getuser(), out)
 
 
     def test_with_context_args(self):
@@ -1115,26 +1115,26 @@ sys.stderr.write("stderr")
         file_obj = tempfile.NamedTemporaryFile()
         out = python(py.name, _out=file_obj)
 
-        self.assertTrue(len(out) == 0)
+        self.assertEqual(len(out), 0)
 
         file_obj.seek(0)
         actual_out = file_obj.read()
         file_obj.close()
 
-        self.assertTrue(len(actual_out) != 0)
+        self.assertEqual(len(actual_out), 0)
 
 
         # test with tee
         file_obj = tempfile.NamedTemporaryFile()
         out = python(py.name, _out=file_obj, _tee=True)
 
-        self.assertTrue(len(out) != 0)
+        self.assertGreater(len(out), 0)
 
         file_obj.seek(0)
         actual_out = file_obj.read()
         file_obj.close()
 
-        self.assertTrue(len(actual_out) != 0)
+        self.assertGreater(len(actual_out), 0)
 
 
 
@@ -1155,9 +1155,9 @@ sys.stderr.write("stderr")
         stderr = file_obj.read().decode()
         file_obj.close()
 
-        self.assertTrue(p.stdout == b"stdout")
-        self.assertTrue(stderr == "stderr")
-        self.assertTrue(len(p.stderr) == 0)
+        self.assertEqual(p.stdout, b"stdout")
+        self.assertEqual(stderr, "stderr")
+        self.assertEqual(len(p.stderr), 0)
 
         # now with tee
         file_obj = tempfile.NamedTemporaryFile()
@@ -1167,9 +1167,9 @@ sys.stderr.write("stderr")
         stderr = file_obj.read().decode()
         file_obj.close()
 
-        self.assertTrue(p.stdout == b"stdout")
-        self.assertTrue(stderr == "stderr")
-        self.assertTrue(len(p.stderr) != 0)
+        self.assertEqual(p.stdout, b"stdout")
+        self.assertEqual(stderr, "stderr")
+        self.assertGreater(len(p.stderr), 0)
 
 
     def test_tty_tee(self):
@@ -1228,8 +1228,8 @@ subprocess.Popen(sys.argv[1:], shell=False).wait()
 
         cmd1 = python.bake(py.name)
         out = cmd1.whoami()
-        self.assertTrue("subcommand" in out)
-        self.assertTrue(getpass.getuser() in out)
+        self.assertIn("subcommand", out)
+        self.assertIn(getpass.getuser(), out)
 
 
     def test_multiple_bakes(self):
@@ -1261,7 +1261,7 @@ sys.stdout.write(str(sys.argv[1:]))
 
         ran = ls("-la").ran
         ft = ran.index("-h")
-        self.assertTrue("-la" in ran[ft:])
+        self.assertIn("-la", ran[ft:])
 
     def test_output_equivalence(self):
         from sh import whoami
@@ -1310,7 +1310,7 @@ for i in range(5): print(i)
         p = python("-u", py.name, _out=agg)
         p.wait()
 
-        self.assertTrue(len(stdout) == 5)
+        self.assertEqual(len(stdout), 5)
 
 
 
@@ -1336,7 +1336,7 @@ for i in range(5):
         # exists when the python process actually starts
         time.sleep(.5)
 
-        self.assertTrue(len(stdout) != 5)
+        self.assertNotEqual(len(stdout), 5)
 
 
 
@@ -1354,7 +1354,7 @@ for i in range(5): print("herpderp")
         p = python("-u", py.name, _out=agg, _out_bufsize=1)
         p.wait()
 
-        self.assertTrue(len(stdout) == 5)
+        self.assertEqual(len(stdout), 5)
 
 
 
@@ -1373,7 +1373,7 @@ for i in range(5): print("herpderp")
         p.wait()
 
         # + 5 newlines
-        self.assertTrue(len(stdout) == (len("herpderp") * 5 + 5))
+        self.assertEqual(len(stdout), len("herpderp") * 5 + 5)
 
 
     def test_stdout_callback_buffered(self):
@@ -1390,7 +1390,7 @@ for i in range(5): sys.stdout.write("herpderp")
         p = python("-u", py.name, _out=agg, _out_bufsize=4)
         p.wait()
 
-        self.assertTrue(len(stdout) == (len("herp") / 2 * 5))
+        self.assertEqual(len(stdout), len("herp") / 2 * 5)
 
 
 
@@ -1412,7 +1412,7 @@ print(derp)
         p = python("-u", py.name, _out=agg, _tee=True)
         p.wait()
 
-        self.assertTrue("derp" in p)
+        self.assertIn("derp", p)
 
 
 
@@ -1433,8 +1433,8 @@ for i in range(5): print(i)
         p = python("-u", py.name, _out=agg, _tee=True)
         p.wait()
 
-        self.assertTrue("4" in p)
-        self.assertTrue("4" not in stdout)
+        self.assertIn("4", p)
+        self.assertNotIn("4", stdout)
 
 
 
@@ -1468,8 +1468,8 @@ for i in range(5):
 
         self.assertTrue(caught_signal)
         self.assertEqual(p.process.exit_code, -signal.SIGTERM)
-        self.assertTrue("4" not in p)
-        self.assertTrue("4" not in stdout)
+        self.assertNotIn("4", p)
+        self.assertNotIn("4", stdout)
 
 
 
@@ -1504,8 +1504,8 @@ for i in range(5):
 
         self.assertTrue(caught_signal)
         self.assertEqual(p.process.exit_code, -signal.SIGKILL)
-        self.assertTrue("4" not in p)
-        self.assertTrue("4" not in stdout)
+        self.assertNotIn("4", p)
+        self.assertNotIn("4", stdout)
 
     def test_general_signal(self):
         import signal
@@ -1558,7 +1558,8 @@ for i in range(42):
         out = []
         for line in python(py.name, _iter=True):
             out.append(int(line.strip()))
-        self.assertTrue(len(out) == 42 and sum(out) == 861)
+        self.assertEqual(len(out), 42)
+        self.assertEqual(sum(out), 861)
 
     def test_iter_unicode(self):
         # issue https://github.com/amoffat/sh/issues/224
@@ -1566,7 +1567,7 @@ for i in range(42):
         txt = create_tmp_test(test_string)
         for line in sh.cat(txt.name, _iter=True):
             break
-        self.assertTrue(len(line) < 1024)
+        self.assertLess(len(line), 1024)
 
     def test_nonblocking_iter(self):
         from errno import EWOULDBLOCK
@@ -1584,7 +1585,7 @@ sys.stdout.write("stdout")
                 count += 1
             else:
                 value = line
-        self.assertTrue(count > 0)
+        self.assertGreater(count, 0)
         self.assertEqual(value, "stdout")
 
         py = create_tmp_test("""
@@ -1601,7 +1602,7 @@ sys.stderr.write("stderr")
                 count += 1
             else:
                 value = line
-        self.assertTrue(count > 0)
+        self.assertGreater(count, 0)
         self.assertEqual(value, "stderr")
 
 
@@ -1619,13 +1620,13 @@ for i in range(42):
         out = []
         for line in python("-u", py.name, _iter="err"):
             out.append(line)
-        self.assertTrue(len(out) == 42)
+        self.assertEqual(len(out), 42)
 
         # verify that nothing is going to stdout
         out = []
         for line in python("-u", py.name, _iter="out"):
             out.append(line)
-        self.assertTrue(len(out) == 0)
+        self.assertEqual(len(out), 0)
 
 
     def test_sigpipe(self):
@@ -1731,8 +1732,8 @@ for i in range(42):
         out = []
         for line in python("-u", py.name, _iter=True, _err=agg): out.append(line)
 
-        self.assertTrue(len(out) == 42)
-        self.assertTrue(sum(stderr) == 1722)
+        self.assertEqual(len(out), 42)
+        self.assertEqual(sum(stderr), 1722)
 
 
     def test_cast_bg(self):
@@ -2038,14 +2039,14 @@ sys.stdout.write("line1")
         else:
             self.fail("no timeout exception")
         elapsed = time() - started
-        self.assertTrue(abs(elapsed - timeout) < 0.5)
+        self.assertLess(abs(elapsed - timeout), 0.5)
 
 
     def test_timeout_overstep(self):
         started = time.time()
         sh.sleep(1, _timeout=5)
         elapsed = time.time() - started
-        self.assertTrue(abs(elapsed - 1) < 0.5)
+        self.assertLess(abs(elapsed - 1), 0.5)
 
 
     def test_timeout_wait(self):
@@ -2383,7 +2384,7 @@ print(time())
         wait_elapsed = time.time() - wait_start
 
         self.assertTrue(callback.called)
-        self.assertTrue(abs(wait_elapsed - 1.0) < 1.0)
+        self.assertLess(abs(wait_elapsed - 1.0), 1.0)
         self.assertEqual(callback.exit_code, 0)
         self.assertTrue(callback.success)
 
@@ -2551,9 +2552,9 @@ sys.stdout.flush()
         time1 = float(time1)
         time2 = float(time2)
         self.assertEqual(word1, "testing")
-        self.assertTrue(abs(1-time1) < 0.5)
+        self.assertLess(abs(1-time1), 0.5)
         self.assertEqual(word2, "done")
-        self.assertTrue(abs(1-time2) < 0.5)
+        self.assertLess(abs(1-time2), 0.5)
 
 
     def test_stdin_newline_bufsize(self):
@@ -2598,9 +2599,9 @@ sys.stdout.flush()
         time1 = float(time1)
         time2 = float(time2)
         self.assertEqual(word1, "testing")
-        self.assertTrue(abs(1-time1) < 0.5)
+        self.assertLess(abs(1-time1), 0.5)
         self.assertEqual(word2, "done")
-        self.assertTrue(abs(1-time2) < 0.5)
+        self.assertLess(abs(1-time2), 0.5)
 
 
     def test_custom_timeout_signal(self):


### PR DESCRIPTION
Sweeping cleanup for:
* Trailing whitespace
* Imprecise assert methods
* Linter warnings

@amoffat I'm thinking of also fixing linter warnings in sh.py and test.py, just because my editor has a huge number of inspection warnings. Would you mind running e.g. flake8 as part of the test suite?