### PR TITLE
Adding find_spec to ModuleImporterFromVariables

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -22,7 +22,7 @@ http://amoffat.github.io/sh/
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 # ===============================================================================
-__version__ = "1.13.2"
+__version__ = "1.13.1"
 __project_url__ = "https://github.com/amoffat/sh"
 
 from collections import deque, Mapping
@@ -3655,7 +3655,7 @@ class ModuleImporterFromVariables(object):
         return self
 
     def find_spec(self, fullname, path=None, target=None):
-        "find_module() is deprecated since Python 3.4 in favor of find_spec()"
+        """ find_module() is deprecated since Python 3.4 in favor of find_spec() """
 
         from importlib.machinery import ModuleSpec
         found = self.find_module(fullname, path)

--- a/sh.py
+++ b/sh.py
@@ -22,7 +22,7 @@ http://amoffat.github.io/sh/
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 # ===============================================================================
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 __project_url__ = "https://github.com/amoffat/sh"
 
 from collections import deque, Mapping
@@ -3627,6 +3627,9 @@ class ModuleImporterFromVariables(object):
 
         parent_frame = inspect.currentframe().f_back
 
+        if parent_frame and parent_frame.f_code.co_name == "find_spec":
+            parent_frame = parent_frame.f_back
+
         while parent_frame and in_importlib(parent_frame):
             parent_frame = parent_frame.f_back
 
@@ -3650,6 +3653,13 @@ class ModuleImporterFromVariables(object):
             return None
 
         return self
+
+    def find_spec(self, fullname, path=None, target=None):
+        "find_module() is deprecated since Python 3.4 in favor of find_spec()"
+
+        from importlib.machinery import ModuleSpec
+        found = self.find_module(fullname, path)
+        return ModuleSpec(fullname, found) if found is not None else None
 
     def load_module(self, mod_fullname):
         parent_frame = inspect.currentframe().f_back


### PR DESCRIPTION
This PR adds the method `find_spec` to `ModuleImporterFromVariables`.

The method `find_module` (implemented in `ModuleImporterFromVariables`) has been deprecated since Python 3.4 in favor of `find_spec`: https://docs.python.org/3/library/sys.html#sys.meta_path

The absence of `find_spec` made me incur in an issue with pytest: https://github.com/pytest-dev/pytest/issues/7689.
This PR would resolve that issue.