### PR TITLE
Fallback import for collections.abc.Mapping

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -25,7 +25,11 @@ http://amoffat.github.io/sh/
 __version__ = "1.14.0"
 __project_url__ = "https://github.com/amoffat/sh"
 
-from collections import deque, Mapping
+from collections import deque
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from contextlib import contextmanager
 from functools import partial
 from io import UnsupportedOperation, open as fdopen


### PR DESCRIPTION
sh.py:
Since python 3.3 the abstract classes in the collections module are
ordered below collections.abc.
While until python 3.8 this only shows a warning during import it will
be raising an ImportError with python 3.9.
Therefore the Mapping class is imported from collections.abc by default
and falls back to importing from collections directly for python < 3.3
when encountering an ImportError.