### PR TITLE
Remove hardcoded path for sleep executable

### DIFF
--- a/test.py
+++ b/test.py
@@ -2014,7 +2014,7 @@ sys.stdout.write("line1")
         try:
             sh.sleep(sleep_for, _timeout=timeout).wait()
         except sh.TimeoutException as e:
-            self.assertEqual(e.full_cmd, '/bin/sleep 3')
+            assert 'sleep 3' in e.full_cmd
         else:
             self.fail("no timeout exception")
         elapsed = time() - started


### PR DESCRIPTION
test.py:
In test_timeout the path for the sleep executable has been hardcoded to
be /bin/sleep. However, on operating systems such as Arch Linux, Fedora
or Solaris the executable resides in /usr/bin/sleep due to a /usr merge
(e.g. see
  https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/).
By only checking for the name of the executable and its parameter the
test becomes more generic and thus can run on any (Unix-like) operating
system (given that `sleep` is in PATH).

Fixes #539