### PR TITLE
Properly raise ErrorReturnCode_0 on exit code 0

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -486,7 +486,7 @@ def get_rc_exc(rc):
     except KeyError:
         pass
 
-    if rc > 0:
+    if rc >= 0:
         name = "ErrorReturnCode_%d" % rc
         base = ErrorReturnCode
     else:

--- a/test.py
+++ b/test.py
@@ -422,6 +422,11 @@ exit(3)
         py = create_tmp_test("exit(0)")
         python(py.name, _ok_code=None)
 
+    def test_ok_code_exception(self):
+        from sh import ErrorReturnCode_0
+        py = create_tmp_test("exit(0)")
+        self.assertRaises(ErrorReturnCode_0, python, py.name, _ok_code=2)
+
     def test_none_arg(self):
         py = create_tmp_test("""
 import sys


### PR DESCRIPTION
This handles the case where exit code 0 is disallowed via '_ok_code' and the process exits with this code.

get_exc_from_name() negates signal numbers and calls get_rc_exc() with either the exit code or the negated signal number. Exit codes are unsigned ints and thus >=0. Signal numbers are always >= 1 (see 'kill -l').

get_rc_exc() erroneously handled '0' as a signal when it should be seen as an exit code.

Fixes #544