### PR TITLE
Cast argument to pushd as str to support passing Paths

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -3191,7 +3191,7 @@ def pushd(path):
     context, unlike the _cwd arg this will work with other built-ins such as
     sh.glob correctly """
     orig_path = os.getcwd()
-    os.chdir(path)
+    os.chdir(str(path))
     try:
         yield
     finally:


### PR DESCRIPTION
Support using [Path](https://docs.python.org/3/library/pathlib.html) as the argument to `sh.pushd` by explicitly casting to `str`.