### PR TITLE
Add docstring for Command.bake

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1300,8 +1300,13 @@ class Command(object):
 
         return call_args, kwargs
 
-    # TODO needs documentation
     def bake(self, *args, **kwargs):
+        """returns a new Command object after baking(freezing) the given 
+        command arguments which are used automatically when its exec'ed
+  
+        special keyword arguments can be temporary baked and additionally
+        be overridden in __call__ or in subsequent bakes (basically setting defaults)"""
+
         # construct the base Command
         fn = type(self)(self._path)
         fn._partial = True


### PR DESCRIPTION
This PR adds docstring for `Command.bake()`.

Closes #587.