### PR TITLE
fix flaky test

### DIFF
--- a/test.py
+++ b/test.py
@@ -1494,7 +1494,6 @@ import time
 import signal
 
 def sig_handler(sig, frame):
-    print(10)
     exit(0)
 
 signal.signal(signal.SIGINT, sig_handler)
@@ -1518,7 +1517,7 @@ for i in range(5):
         p.wait()
 
         self.assertEqual(p.process.exit_code, 0)
-        self.assertEqual(p, "0\n1\n2\n3\n10\n")
+        self.assertEqual(p, "0\n1\n2\n3\n")
 
     def test_iter_generator(self):
         py = create_tmp_test("""

--- a/test.py
+++ b/test.py
@@ -1493,13 +1493,16 @@ import os
 import time
 import signal
 
+i = 0
 def sig_handler(sig, frame):
-    exit(0)
+    global i
+    i = 42
 
 signal.signal(signal.SIGINT, sig_handler)
 
-for i in range(5):
+for _ in range(6):
     print(i)
+    i += 1
     sys.stdout.flush()
     time.sleep(0.5)
 """)
@@ -1517,7 +1520,7 @@ for i in range(5):
         p.wait()
 
         self.assertEqual(p.process.exit_code, 0)
-        self.assertEqual(p, "0\n1\n2\n3\n")
+        self.assertEqual(p, "0\n1\n2\n3\n42\n43\n")
 
     def test_iter_generator(self):
         py = create_tmp_test("""


### PR DESCRIPTION
[When building a python3.10 CI env](https://github.com/mdtraj/mdtraj/runs/4142910454?check_suite_focus=true), the build of this package failed one of the tests:
```python

ERROR: test_general_signal (test.FunctionalTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/sh-1.14.2/test.py", line 1546, in test_general_signal
    p = python(py.name, _out=agg, _tee=True)
  File "/build/sh-1.14.2/sh.py", line 1566, in __call__
    return RunningCommand(cmd, call_args, stdin, stdout, stderr)
  File "/build/sh-1.14.2/sh.py", line 822, in __init__
    self.wait()
  File "/build/sh-1.14.2/sh.py", line 879, in wait
    self.handle_command_exit_code(exit_code)
  File "/build/sh-1.14.2/sh.py", line 905, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 

  RAN: /nix/store/19pr23xsafq6psd8jpa6fcjbz8j0si6i-python3-3.10.0/bin/python3.10 /build/tmp83hhw5f5

  STDOUT:
0
1
2
3


  STDERR:
Traceback (most recent call last):
  File "/build/tmp83hhw5f5", line 14, in <module>
    print(i)
  File "/build/tmp83hhw5f5", line 8, in sig_handler
    print(10)
RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>


----------------------------------------------------------------------
Ran 171 tests in 48.500s

FAILED (errors=1, skipped=3)
Test failed: <unittest.runner.TextTestResult run=171 errors=1 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=171 errors=1 failures=0>
```

@rmcgibbo figured out in [this comment](https://github.com/mdtraj/mdtraj/pull/1688#issuecomment-963477347) that this test is probably wrong (when looking at this bug report: https://bugs.python.org/issue24283 ). This removes the offending line and relies on the `exit(0)` to notify the correct handling of the signal.

PLease let me know if you want this to go into a different branch