### PR TITLE
Added password kwarg

### DIFF
--- a/_docs_sources/sections/sudo.rst
+++ b/_docs_sources/sections/sudo.rst
@@ -70,7 +70,7 @@ You may also specify your password to ``sh.contrib.sudo`` as a string:
 
     password = get_your_password()
 
-    with sh.contrib.sudo(password, _with=True):
+    with sh.contrib.sudo(password=password, _with=True):
         print(ls("/root"))
 
 .. warning::


### PR DESCRIPTION
The example of using `sh.contrib.sudo` with a string password highly confused me as it was missing the crucial bit that the password must be passed via a keyword argument.