### PR TITLE
Accept pathlib.Path objects for stdout/stderr

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -990,7 +990,7 @@ class RunningCommand(object):
 
 
 def output_redirect_is_filename(out):
-    return isinstance(out, basestring)
+    return isinstance(out, basestring) or hasattr(out, '__fspath__')
 
 
 def get_prepend_stack():

--- a/test.py
+++ b/test.py
@@ -136,6 +136,7 @@ requires_utf8 = skipUnless(sh.DEFAULT_ENCODING == "UTF-8", "System encoding must
 not_macos = skipUnless(not IS_MACOS, "Doesn't work on MacOS")
 requires_py3 = skipUnless(IS_PY3, "Test only works on Python 3")
 requires_py35 = skipUnless(IS_PY3 and MINOR_VER >= 5, "Test only works on Python 3.5 or higher")
+requires_py36 = skipUnless(IS_PY3 and MINOR_VER >= 6, "Test only works on Python 3.6 or higher")
 
 
 def requires_poller(poller):
@@ -1772,7 +1773,7 @@ exit(code)
         outfile.seek(0)
         self.assertEqual(b"output\n", outfile.read())
 
-    @requires_py35
+    @requires_py36
     def test_out_pathlike(self):
         from pathlib import Path
         outfile = tempfile.NamedTemporaryFile()

--- a/test.py
+++ b/test.py
@@ -1772,6 +1772,15 @@ exit(code)
         outfile.seek(0)
         self.assertEqual(b"output\n", outfile.read())
 
+    @requires_py35
+    def test_out_pathlike(self):
+        from pathlib import Path
+        outfile = tempfile.NamedTemporaryFile()
+        py = create_tmp_test("print('output')")
+        python(py.name, _out=Path(outfile.name))
+        outfile.seek(0)
+        self.assertEqual(b"output\n", outfile.read())
+
     def test_bg_exit_code(self):
         py = create_tmp_test("""
 import time


### PR DESCRIPTION
Fix #597.
I decided to not add an additional import for `pathlib.Path` and instead check if the object passed is "path-like" according to [PEP-519](https://www.python.org/dev/peps/pep-0519/).