### PR TITLE
fix: Rename cmd to command in OProc.__repr__

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2309,7 +2309,7 @@ class OProc(object):
             )
 
     def __repr__(self):
-        return "<Process %d %r>" % (self.pid, self.command[:500])
+        return "<Process %d %r>" % (self.pid, self.command.cmd[:500])
 
     # these next 3 properties are primary for tests
     @property

--- a/sh.py
+++ b/sh.py
@@ -2309,7 +2309,7 @@ class OProc(object):
             )
 
     def __repr__(self):
-        return "<Process %d %r>" % (self.pid, self.cmd[:500])
+        return "<Process %d %r>" % (self.pid, self.command[:500])
 
     # these next 3 properties are primary for tests
     @property


### PR DESCRIPTION
Fix the AttributeError raised when using __repr__ in "OProc".

This issue is annoying when you use a debugger and it tries to represent every object in the frame.