### PR TITLE
Explain type of argument passed to output callback

### DIFF
--- a/_docs_sources/sections/asynchronous_execution.rst
+++ b/_docs_sources/sections/asynchronous_execution.rst
@@ -97,6 +97,10 @@ To control whether the callback receives a line or a chunk, use
 :ref:`out_bufsize`.  To "quit" your callback, simply return ``True``.  This
 tells the command not to call your callback anymore.
 
+The line or chunk received by the callback can either be of type ``str`` or
+``bytes``. If the output could be decoded using the provided :ref:`encoding`, a
+``str`` will be passed to the callback, otherwise it would be raw ``bytes``.
+
 .. note::
 
     Returning ``True`` does not kill the process, it only keeps the callback


### PR DESCRIPTION
Not sure whether this is already mentioned in other parts of the doc, and I think it could be useful to mention it where we explain callback.