### PR TITLE
[wip] Searching commands, use PATH from baked-in `_env`

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -592,7 +592,7 @@ def resolve_command_path(program, paths=None):
 def resolve_command(name, baked_args=None):
     paths = None
     if baked_args and '_env' in baked_args:
-        paths = baked_args['_env'].get('PATH').split(os.pathsep)
+        paths = baked_args['_env'].get('PATH', '').split(os.pathsep)
     path = resolve_command_path(name, paths)
     cmd = None
     if path:

--- a/sh.py
+++ b/sh.py
@@ -575,22 +575,25 @@ def which(program, paths=None):
     return found_path
 
 
-def resolve_command_path(program):
-    path = which(program)
+def resolve_command_path(program, paths=None):
+    path = which(program, paths)
     if not path:
         # our actual command might have a dash in it, but we can't call
         # that from python (we have to use underscores), so we'll check
         # if a dash version of our underscore command exists and use that
         # if it does
         if "_" in program:
-            path = which(program.replace("_", "-"))
+            path = which(program.replace("_", "-"), paths)
         if not path:
             return None
     return path
 
 
 def resolve_command(name, baked_args=None):
-    path = resolve_command_path(name)
+    paths = None
+    if baked_args and '_env' in baked_args:
+        paths = baked_args['_env'].get('PATH').split(os.pathsep)
+    path = resolve_command_path(name, paths)
     cmd = None
     if path:
         cmd = Command(path)


### PR DESCRIPTION
This modifies `resolve_command` and `resolve_command_path` to respect the `PATH` from a baked-in `_env` option.

### Problem & Solution
It is difficult to use `sh` to access executables in a venv.
If `sh` respects a baked-in `_env` argument when searching commands, it works acceptably.
Note that this also extends to respecting the path of the baked-in `_env` in general.

#### Example Program
Installed into venv's `bin` folder.
```python
#! python3
print('moop!')
```

#### Example Before PR
```python
# enter a virtual environment
# naive, but just an example.
>>> venv = dict([line[:-1].split('=', 1) for line in sh.bash('-c', '. test/bin/activate && env')])
>>> vsh = sh.bake(_env=venv)
>>> vsh.moop()
[traceback...]
CommandNotFound: moop
```
#### Example after PR
```python
# enter a virtual environment
# naive, but just an example.
>>> venv = dict([line[:-1].split('=', 1) for line in sh.bash('-c', '. test/bin/activate && env')])
>>> vsh = sh.bake(_env=venv)
>>> vsh.moop()
moop!
```

Now, it would be a nice feature if there were a way to set the `venv` by specifying an `activate` file, like:
vsh = sh._activate('test/bin/activate')

..however, this is functional enough and all I have time for.  I thought you might be interested in it.