### PR TITLE
docs: Fix a few typos

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -668,7 +668,7 @@ class RunningCommand(object):
     this is the class that gets manipulated the most by user code, and so it
     implements various convenience methods and logical mechanisms for the
     underlying process.  for example, if a user tries to access a
-    backgrounded-process's stdout/err, the RunningCommand object is smart enough
+    background-process's stdout/err, the RunningCommand object is smart enough
     to know to wait() on the process to finish first.  and when the process
     finishes, RunningCommand is smart enough to translate exit codes to
     exceptions. """
@@ -1972,7 +1972,7 @@ class OProc(object):
 
             try:
                 # ignoring SIGHUP lets us persist even after the parent process
-                # exits.  only ignore if we're backgrounded
+                # exits.  only ignore if we're background
                 if ca["bg"] is True:
                     signal.signal(signal.SIGHUP, signal.SIG_IGN)
 

--- a/test.py
+++ b/test.py
@@ -617,7 +617,7 @@ import os
 print(len(os.listdir("/dev/fd")))
 """)
         out = python(py.name, _close_fds=False).strip()
-        # pick some number greater than 4, since it's hard to know exactly how many fds will be open/inherted in the
+        # pick some number greater than 4, since it's hard to know exactly how many fds will be open/inherited in the
         # child
         self.assertGreater(int(out), 7)
 


### PR DESCRIPTION
There are small typos in:
- sh.py
- test.py

Fixes:
- Should read `background` rather than `backgrounded`.
- Should read `inherited` rather than `inherted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md