### PR TITLE
POC: Add lazy resolving of command paths

### DIFF
--- a/test.py
+++ b/test.py
@@ -740,18 +740,20 @@ exit(2)
 
         def do_import():
             from sh import aowjgoawjoeijaowjellll  # noqa: F401
-
-        self.assertRaises(ImportError, do_import)
-
-        def do_import():
-            import sh
-            sh.awoefaowejfw
+            aowjgoawjoeijaowjellll()
 
         self.assertRaises(CommandNotFound, do_import)
 
         def do_import():
             import sh
-            sh.Command("ofajweofjawoe")
+            sh.awoefaowejfw()
+
+        self.assertRaises(CommandNotFound, do_import)
+
+        def do_import():
+            import sh
+            cmd = sh.Command("ofajweofjawoe")
+            cmd()
 
         self.assertRaises(CommandNotFound, do_import)
 
@@ -2744,18 +2746,6 @@ class MockTests(BaseTests):
         @unittest.mock.patch("sh.Command")
         def test(Command):
             Command().return_value = "some output"
-            return fn()
-
-        self.assertEqual(test(), "some output")
-        self.assertRaises(sh.CommandNotFound, fn)
-
-    def test_patch_command(self):
-        def fn():
-            return sh.afowejfow()
-
-        @unittest.mock.patch("sh.afowejfow", create=True)
-        def test(cmd):
-            cmd.return_value = "some output"
             return fn()
 
         self.assertEqual(test(), "some output")


### PR DESCRIPTION
Defer resolving of the actual command path to when the command is called, not when it's imported. This allows providing a custom PATH via _env to customize resolving of the command path.

Remove test case that only tested if the mocker works.

NOTE: this is just a proof of concept of how lazy resolving could work. See discussions in https://github.com/amoffat/sh/pull/602