### PR TITLE
explicitly set 'exit_code' on 'ErrorReturnCode'

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -366,6 +366,7 @@ class ErrorReturnCode(Exception):
         return self.__class__, (self.full_cmd, self.stdout, self.stderr, self.truncate)
 
     def __init__(self, full_cmd, stdout, stderr, truncate=True):
+        self.exit_code = self.exit_code
         self.full_cmd = full_cmd
         self.stdout = stdout
         self.stderr = stderr


### PR DESCRIPTION
This commit explicitly defines 'exit_code' for ErrorReturnCode class to prevent false-positives from linters, i.e. pylint.

Example:
```py
import sh

try:
    sh.bash("-c", "exit 1")
except sh.ErrorReturnCode as error:
    print(error.exit_code)
```

```sh
$ pylint ./example.py
...
E1101: Instance of 'ErrorReturnCode' has no 'exit_code' member (no-member)
```

This happens because 'exit_code' is defined during metaclass initialization (see `get_rc_exc` function), and pylint does not handle such members correctly.

Explicitly setting 'exit_code' during 'ErrorReturnCode' initialization to itself gives pylint enough info to deduce that this class actually has 'exit_code' member.