### PR TITLE
Make fd/file_chunk_consumer respect decode_errors

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2902,7 +2902,7 @@ def determine_how_to_feed_output(handler, encoding, decode_errors):
         process, finish = get_stringio_chunk_consumer(handler, encoding, decode_errors)
 
     elif hasattr(handler, "write"):
-        process, finish = get_file_chunk_consumer(handler)
+        process, finish = get_file_chunk_consumer(handler, decode_errors)
 
     else:
         try:
@@ -2911,19 +2911,19 @@ def determine_how_to_feed_output(handler, encoding, decode_errors):
             def process(chunk): return False  # noqa: E731
             def finish(): return None  # noqa: E731
         else:
-            process, finish = get_fd_chunk_consumer(handler)
+            process, finish = get_fd_chunk_consumer(handler, decode_errors)
 
     return process, finish
 
 
-def get_fd_chunk_consumer(handler):
+def get_fd_chunk_consumer(handler, decode_errors):
     handler = fdopen(handler, "w", closefd=False)
-    return get_file_chunk_consumer(handler)
+    return get_file_chunk_consumer(handler, decode_errors)
 
 
-def get_file_chunk_consumer(handler):
+def get_file_chunk_consumer(handler, decode_errors):
     if getattr(handler, "encoding", None):
-        def encode(chunk): return chunk.decode(handler.encoding)  # noqa: E731
+        def encode(chunk): return chunk.decode(handler.encoding, decode_errors)  # noqa: E731
     else:
         def encode(chunk): return chunk  # noqa: E731
 

--- a/test.py
+++ b/test.py
@@ -2160,9 +2160,9 @@ import os
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb')
 IS_PY3 = sys.version_info[0] == 3
 if IS_PY3:
-    sys.stdout.write(bytes("te漢字st", "utf8"))
+    sys.stdout.write(bytes("te漢字st", "utf8") + "äåéë".encode("latin_1"))
 else:
-    sys.stdout.write("te漢字st")
+    sys.stdout.write("te漢字st" + u"äåéë".encode("latin_1"))
 """)
         fn = partial(python, py.name, _encoding="ascii")
 
@@ -2171,6 +2171,9 @@ else:
         self.assertRaises(UnicodeDecodeError, s, fn)
 
         p = python(py.name, _encoding="ascii", _decode_errors="ignore")
+        self.assertEqual(p, "test")
+
+        p = python(py.name, _encoding="ascii", _decode_errors="ignore", _out=sys.stdout, _tee=True)
         self.assertEqual(p, "test")
 
     def test_signal_exception(self):


### PR DESCRIPTION
This fixes the example I provided at
https://github.com/amoffat/sh/issues/556#issuecomment-1281119556 by making fd/file_chunk_consumer respect decode_errors just like the other consumers.