### PR TITLE
Lower is_alive lock timeout

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2495,7 +2495,7 @@ class OProc(object):
         # Using a small timeout provides backpressure against code that spams
         # calls to .is_alive() which may block the main thread from acquiring
         # the lock otherwise.
-        acquired = self._wait_lock.acquire(timeout=0.1)
+        acquired = self._wait_lock.acquire(timeout=0.00001)
         if not acquired:
             if self.exit_code is not None:
                 return False, self.exit_code


### PR DESCRIPTION
This sets the lock timeout back to `0.00001` as it was before https://github.com/amoffat/sh/commit/e9511de5ca9b1d1bf0b42da51fa40073a73fa4d6. I don't have context on why it was raised to 0.1, but given we're using the `acquire` provided timeout from https://github.com/amoffat/sh/pull/650, is the low timeout fine now?

Follow up to https://github.com/amoffat/sh/pull/650 in light of https://github.com/amoffat/sh/issues/649#issuecomment-1426858103.

cc @ypsah