### PR TITLE
Make sure new_group never creates new session

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -2037,7 +2037,7 @@ class OProc(object):
                 if new_session:
                     os.setsid()
                 elif new_group:
-                    os.setpgrp()
+                    os.setpgid(0, 0)
 
                 sid = os.getsid(0)
                 pgid = os.getpgid(0)


### PR DESCRIPTION
According to [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgrp.html) it is unspecified whether the `setpgrp()` function should behave like `setpgid(0,0)` or `setsid()`.  While the `sh` project assumes it is always like `setpgid(0,0)` this is not the case for operating systems like illumos or Solaris.

This fixes the `new_group` to newer create new session on POSIX compliant operating systems.

Please note that `setpgrp()` is currently considered obsolete by POSIX.

Fixes #671