### PR TITLE
Fix nested contexts duplicating commands

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1425,7 +1425,10 @@ class Command(object):
             pcall_args.pop("with", None)
 
             call_args.update(pcall_args)
-            cmd.extend(prepend.cmd)
+            # we do not prepend commands used as a 'with' context as they will
+            # be prepended to any nested commands
+            if not kwargs.get("_with", False):
+                cmd.extend(prepend.cmd)
 
         cmd.append(self._path)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1101,6 +1101,13 @@ if options.opt:
             out = whoami()
         self.assertEqual(out.strip(), "")
 
+    def test_with_context_nested(self):
+        echo_path = sh.echo._path
+        with sh.echo.bake("test1", _with=True):
+            with sh.echo.bake("test2", _with=True):
+                out = sh.echo("test3")
+        self.assertEqual(out.strip(), f"test1 {echo_path} test2 {echo_path} test3")
+
     def test_binary_input(self):
         py = create_tmp_test(
             """


### PR DESCRIPTION
This PR fixes an issue where using nested command contexts would duplicate commands upon execution. This comes about because all created commands are prepended by any containing commands used as a with-context. Since commands used as a with-context also get prepended, we end up getting duplicated commands when are contexts are nested.

We solve the problem by simply not prepending to commands used as a context.

Resolves #690 