### PR TITLE
chore: nicer error message for windows users

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -28,7 +28,11 @@ from collections import deque
 from collections.abc import Mapping
 
 import errno
-import fcntl
+
+try:
+    import fcntl
+except ImportError:
+    raise RuntimeError("This only works on *nix systems. Try Docker?")
 import gc
 import getpass
 import glob as glob_module


### PR DESCRIPTION
From https://phpc.social/deck/@mistersql@mastodon.social/113314907209898815
![image](https://github.com/user-attachments/assets/93e21532-08bf-4cb4-939b-0428f4c85dea)

Hi, curious library. Users are complaining on socials about using [python because of] it, and I'm not sure it's fair on either side.

I Can see that sysops folks might not want to use python in the same way I want to. (I would open a damn sub-process)

This new error lets folks know that only unix style python is supported, and points them at Docker, which I see you make use of in this repo.

The core use case is:

As a user, who has been able to successfully `pip install sh`
I would like to receive meaningful errors, that signpost me
So that I do not rage on socials, about python itself, or try to install non-packages such as `fnctl`

I do also intend upon raising this with python. Maybe this would be a good stub behaviour for `fnctl` so that users at least know "hey we deliberately chose not to include this" rather than `"Module not found"`