### PR TITLE
Avoid manual async loop management

### DIFF
--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1707,7 +1707,6 @@ print("hello")
         )
 
         alternating = []
-        q = AQueue()
 
         async def producer(q):
             alternating.append(1)
@@ -1722,9 +1721,11 @@ print("hello")
             self.assertEqual(msg, "hello")
             alternating.append(2)
 
-        loop = asyncio.get_event_loop()
-        fut = asyncio.gather(producer(q), consumer(q))
-        loop.run_until_complete(fut)
+        async def main():
+            q = AQueue()
+            await asyncio.gather(producer(q), consumer(q))
+
+        asyncio.run(main())
         self.assertListEqual(alternating, [1, 2, 1, 2])
 
     def test_async_exc(self):
@@ -1733,8 +1734,7 @@ print("hello")
         async def producer():
             await python(py.name, _async=True)
 
-        loop = asyncio.get_event_loop()
-        self.assertRaises(sh.ErrorReturnCode_34, loop.run_until_complete, producer())
+        self.assertRaises(sh.ErrorReturnCode_34, asyncio.run, producer())
 
     def test_async_iter(self):
         py = create_tmp_test(
@@ -1743,7 +1743,6 @@ for i in range(5):
     print(i)
 """
         )
-        q = AQueue()
 
         # this list will prove that our coroutines are yielding to eachother as each
         # line is produced
@@ -1763,9 +1762,11 @@ for i in range(5):
                     return
                 alternating.append(2)
 
-        loop = asyncio.get_event_loop()
-        res = asyncio.gather(producer(q), consumer(q))
-        loop.run_until_complete(res)
+        async def main():
+            q = AQueue()
+            await asyncio.gather(producer(q), consumer(q))
+
+        asyncio.run(main())
         self.assertListEqual(alternating, [1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
 
     def test_async_iter_exc(self):
@@ -1783,8 +1784,7 @@ exit(34)
             async for line in python(py.name, _async=True):
                 lines.append(int(line.strip()))
 
-        loop = asyncio.get_event_loop()
-        self.assertRaises(sh.ErrorReturnCode_34, loop.run_until_complete, producer())
+        self.assertRaises(sh.ErrorReturnCode_34, asyncio.run, producer())
 
     def test_handle_both_out_and_err(self):
         py = create_tmp_test(


### PR DESCRIPTION
Python 3.14 removes the implicit creation of an event loop when running asyncio.get_event_loop().  Rather than manually managing the loop creation, switch the async tests to use the higher level asyncio.run() interface, as recommended by the standard library docs.

https://docs.python.org/dev/whatsnew/3.14.html#id4

Resolves #741