### PR TITLE
await command with _return_cmd True returns RunningCommand

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -889,7 +889,10 @@ class RunningCommand:
     def __await__(self):
         async def wait_for_completion():
             await self.aio_output_complete.wait()
-            return str(self)
+            if self.call_args["return_cmd"]:
+                return self
+            else:
+                return str(self)
 
         return wait_for_completion().__await__()
 

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1732,7 +1732,7 @@ print("hello")
         py = create_tmp_test("""exit(34)""")
 
         async def producer():
-            await python(py.name, _async=True)
+            await python(py.name, _async=True, _return_cmd=False)
 
         self.assertRaises(sh.ErrorReturnCode_34, asyncio.run, producer())
 
@@ -1785,6 +1785,22 @@ exit(34)
                 lines.append(int(line.strip()))
 
         self.assertRaises(sh.ErrorReturnCode_34, asyncio.run, producer())
+
+    def test_async_return_cmd(self):
+        py = create_tmp_test(
+            """
+import sys
+sys.exit(0)
+"""
+        )
+
+        async def main():
+            result = await python(py.name, _async=True, _return_cmd=True)
+            self.assertIsInstance(result, sh.RunningCommand)
+            result_str = await python(py.name, _async=True, _return_cmd=False)
+            self.assertIsInstance(result_str, str)
+
+        asyncio.run(main())
 
     def test_handle_both_out_and_err(self):
         py = create_tmp_test(


### PR DESCRIPTION
If _return_cmd is True, have __await__ return the RunningCommand object rather than a string representation. Fixes #743

I'm having trouble getting the lint tox environment to pass; it fails even before my change wanting to reformat sh.py. I don't understand what the diff is trying to do so I don't know if it is a local environmental issue or something else.