### PR TITLE
async return_cmd should raise on failure

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -890,6 +890,9 @@ class RunningCommand:
         async def wait_for_completion():
             await self.aio_output_complete.wait()
             if self.call_args["return_cmd"]:
+                # We know the command has completed already,
+                # but need to catch exceptions
+                self.wait()
                 return self
             else:
                 return str(self)

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1802,6 +1802,19 @@ sys.exit(0)
 
         asyncio.run(main())
 
+    def test_async_return_cmd_exc(self):
+        py = create_tmp_test(
+            """
+import sys
+sys.exit(1)
+"""
+        )
+
+        async def main():
+            await python(py.name, _async=True, _return_cmd=True)
+
+        self.assertRaises(sh.ErrorReturnCode_1, asyncio.run, main())
+
     def test_handle_both_out_and_err(self):
         py = create_tmp_test(
             """


### PR DESCRIPTION
Commit 3a9d8ce9fb incorrectly suppresses exceptions when a return_cmd True RunningCommand is awaited.

Explicitly check for exceptions so they are properly raised.