### PR TITLE
Full documentation as a single page for LLMs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ systems - Linux, macOS, BSDs etc. Specifically, Windows is not supported.
 
 `Complete documentation here <https://sh.readthedocs.io/>`_
 
+`Full documentation on a single page for LLM-assisted coding here <https://sh.readthedocs.io/en/latest/fulldoc.html>`_
+
 Installation
 ============
 

--- a/docs/source/fulldoc.rst
+++ b/docs/source/fulldoc.rst
@@ -1,0 +1,35 @@
+Full Documentation
+==================
+
+This single page repeats the full documentation for `sh <https://github.com/amoffat/sh/>`, making it easier to put into an LLM's context window. There is nothing on this page that is not mentionned already elsewhere on this site, it's just reorganized as a single page.
+
+.. include:: index.rst
+
+.. include:: tutorials/interacting_with_processes.rst
+.. include:: tutorials/real_time_output.rst
+
+
+.. content linked in index.rst
+.. include:: sections/faq.rst
+.. include:: sections/contrib.rst
+.. include:: sections/sudo.rst
+
+.. content of usage.rst
+.. include:: sections/passing_arguments.rst
+.. include:: sections/exit_codes.rst
+.. include:: sections/redirection.rst
+.. include:: sections/asynchronous_execution.rst
+.. also contains reference to example/done.rst so no need to mention it explicitely
+.. .. include:: examples/done.rst
+.. include:: sections/baking.rst
+.. include:: sections/piping.rst
+.. include:: sections/subcommands.rst
+.. include:: sections/default_arguments.rst
+.. include:: sections/envs.rst
+.. include:: sections/stdin.rst
+.. include:: sections/with.rst
+
+.. content of reference.rst
+.. include:: sections/special_arguments.rst
+.. include:: sections/architecture.rst
+.. include:: sections/command_class.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,8 @@
     tutorials
     sections/faq
 
+    ref_to_fulldoc
+
 .. image:: images/logo-230.png
     :alt: Logo
 
@@ -156,3 +158,5 @@ Background Processes
     p.wait()
 
 :ref:`Read More <background>`
+
+.. include:: ref_to_fulldoc.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,9 +8,9 @@
     sections/contrib
     sections/sudo
 
-    tutorials 
+    tutorials
     sections/faq
-    
+
 .. image:: images/logo-230.png
     :alt: Logo
 

--- a/docs/source/ref_to_fulldoc.rst
+++ b/docs/source/ref_to_fulldoc.rst
@@ -1,0 +1,6 @@
+Single Page
+===========
+
+The page below repeats the full documentation for `sh <https://github.com/amoffat/sh/>` as a single page, making it easier to put into an LLM's context window.
+
+:doc:`./fulldoc`


### PR DESCRIPTION
- **whitespace**
- **doc: add full doc as a single page for LLMs**

As discussed in #754

On my local build, done with `cd docs` then `make clean html`, there's the header issue but it might be just me, might be a readthedocs bug and might happen in the website version, and is not that bad anyway IMHO.

edit: put in draft again until I double check the errors when building the docs