### PR TITLE
fix: missing theme install for proper docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 toml==0.10.2
+sphinx-rtd-theme==1.2.2


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

Hopefully this fixes the [documentation not building](https://app.readthedocs.org/projects/sh/builds/) as reported in #755


Here's the [link to the raw build error log](https://app.readthedocs.org/api/v2/build/28114011.txt)