### PR TITLE
Add 'x' command argument for tracing

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1273,6 +1273,8 @@ class Command:
         # sometimes we may return just a plain unicode string
         "return_cmd": False,
         "async": False,
+        # whether to echo each command before executing it
+        "x": False,
     }
 
     # this is a collection of validators to make sure the special kwargs make
@@ -1478,6 +1480,8 @@ class Command:
         final_args = split_args
 
         cmd.extend(final_args)
+        if call_args["x"]:
+            print(' '.join(cmd))
 
         # if we're running in foreground mode, we need to completely bypass
         # launching a RunningCommand and OProc and just do a spawn

--- a/sh.py
+++ b/sh.py
@@ -1481,7 +1481,7 @@ class Command:
 
         cmd.extend(final_args)
         if call_args["x"]:
-            print(' '.join(cmd))
+            print(" ".join(cmd))
 
         # if we're running in foreground mode, we need to completely bypass
         # launching a RunningCommand and OProc and just do a spawn

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -3235,13 +3235,14 @@ sys.exit(1)
 
     def test_x(self):
         import sh
+
         stdout = StringIO()
         original_stdout = sys.stdout
         sys.stdout = stdout
 
-        echo = sh.echo('hello', 'world', _x=True, _return_cmd=True)
+        echo = sh.echo("hello", "world", _x=True, _return_cmd=True)
 
-        self.assertIn(str(' '.join(echo.cmd)), stdout.getvalue().strip())
+        self.assertIn(str(" ".join(echo.cmd)), stdout.getvalue().strip())
         sys.stdout = original_stdout
 
 

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -3233,6 +3233,17 @@ sys.exit(1)
             else:
                 self.assertEqual(p.exit_code, -sig)
 
+    def test_x(self):
+        import sh
+        stdout = StringIO()
+        original_stdout = sys.stdout
+        sys.stdout = stdout
+
+        echo = sh.echo('hello', 'world', _x=True, _return_cmd=True)
+
+        self.assertIn(str(' '.join(echo.cmd)), stdout.getvalue().strip())
+        sys.stdout = original_stdout
+
 
 class MockTests(BaseTests):
     def test_patch_command_cls(self):


### PR DESCRIPTION
Similar to `set -x` in bash, echos the command to stdout before executing anything.

One of my biggest complaints about using sh in place of shell scripting is that I can't bake-in something that echos the commands that are about to be run, so my scripts are littered with prints. I would love to be able to add `_x=True` to my bake arguments and see what's going to be run.

Given that `set -x` is specific to the shells I'm used to, I could also imagine `_trace=True` or `_explicit=True` being more approachable. Thanks in advance for any suggestions!