### PR TITLE
Fix boolean bake override not working

### DIFF
--- a/sh.py
+++ b/sh.py
@@ -1388,6 +1388,19 @@ class Command:
         sep = call_args.get("long_sep", self._call_args["long_sep"])
         prefix = call_args.get("long_prefix", self._call_args["long_prefix"])
         fn._partial_baked_args.extend(compile_args(args, kwargs, sep, prefix))
+
+        # filter out previously baked args that are overridden with False
+        for key, val in kwargs.items():
+            if val is not False:
+                continue
+            if len(key) == 1:
+                flag = "-" + key
+            else:
+                flag = prefix + key.replace("_", "-")
+            fn._partial_baked_args = [
+                a for a in fn._partial_baked_args if a != flag
+            ]
+
         return fn
 
     def __str__(self):
@@ -1472,8 +1485,19 @@ class Command:
             args, kwargs, call_args["long_sep"], call_args["long_prefix"]
         )
 
+        # filter out baked args that are overridden with False in the call
+        baked_args = list(self._partial_baked_args)
+        for key, val in kwargs.items():
+            if val is not False:
+                continue
+            if len(key) == 1:
+                flag = "-" + key
+            else:
+                flag = call_args["long_prefix"] + key.replace("_", "-")
+            baked_args = [a for a in baked_args if a != flag]
+
         # makes sure our arguments are broken up correctly
-        split_args = self._partial_baked_args + processed_args
+        split_args = baked_args + processed_args
 
         final_args = split_args
 

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1369,6 +1369,31 @@ sys.stdout.write(str(sys.argv[1:]))
         out = python.bake(py.name).bake("bake1").bake("bake2")()
         self.assertEqual("['bake1', 'bake2']", str(out))
 
+    def test_bake_boolean_override(self):
+        """Passing a=False in __call__ should override a baked a=True."""
+        py = create_tmp_test(
+            """
+import sys
+sys.stdout.write(str(sys.argv[1:]))
+"""
+        )
+
+        # short arg: bake True, call with False should drop the flag
+        out = python.bake(py.name, a=True)(a=False)
+        self.assertNotIn("'-a'", str(out))
+
+        # short arg: bake False, call with True should add the flag
+        out = python.bake(py.name, a=False)(a=True)
+        self.assertIn("'-a'", str(out))
+
+        # long arg: bake True, call with False should drop the flag
+        out = python.bake(py.name, verbose=True)(verbose=False)
+        self.assertNotIn("'--verbose'", str(out))
+
+        # chained bakes: later bake overrides earlier
+        out = python.bake(py.name).bake(a=True).bake(a=False)()
+        self.assertNotIn("'-a'", str(out))
+
     def test_arg_preprocessor(self):
         py = create_tmp_test(
             """


### PR DESCRIPTION
When a boolean argument is baked as `True` (e.g. `ls.bake(a=True)`), calling with `a=False` should override it and drop the flag. Currently the `False` value is silently discarded by `compile_args` while the baked `-a` flag remains in the argument list, so the override has no effect.

This fixes it by filtering out previously baked flags when a `False` override is passed, both in `bake()` (for chained bakes) and `__call__()` (for call-time overrides).

Fixes #753
