### PR TITLE
Fix `RunningCommand` stubtest errors

### DIFF
--- a/src/sh/__init__.py
+++ b/src/sh/__init__.py
@@ -618,9 +618,6 @@ class RunningCommand:
         "sid",
         "pgid",
         "ctty",
-        "input_thread_exc",
-        "output_thread_exc",
-        "bg_thread_exc",
     }
 
     def __init__(self, cmd, call_args, stdin, stdout, stderr):

--- a/src/sh/__init__.pyi
+++ b/src/sh/__init__.pyi
@@ -14,7 +14,7 @@ from collections.abc import AsyncIterator, Callable, Generator, Iterable, Set
 from contextlib import contextmanager
 from queue import Queue
 from types import GenericAlias, TracebackType
-from typing import Any, ClassVar, Generic, IO, Literal, TypeAlias, overload
+from typing import IO, Any, ClassVar, Final, Generic, Literal, Self, TypeAlias, overload
 
 from typing_extensions import TypeVar
 
@@ -510,9 +510,21 @@ class OProc:
 
 class RunningCommand(str):
     ran: str
-    call_args: dict[str, Any]
     cmd: list[str]
+    call_args: dict[str, Any]
     process: OProc
+
+    # proxied `process` attributes via `__getattr__` from `_OProc_attr_allowlist`
+    # (stubtest would complain if we'd use methods and properties here)
+    signal: Final[Callable[[int], None]]
+    terminate: Final[Callable[[], None]]
+    kill: Final[Callable[[], None]]
+    kill_group: Final[Callable[[], None]]
+    signal_group: Final[Callable[[int], None]]
+    pid: Final[int]
+    sid: Final[int]
+    pgid: Final[int]
+    ctty: Final[str | None]
 
     @property
     def stdout(self) -> bytes: ...
@@ -520,22 +532,43 @@ class RunningCommand(str):
     def stderr(self) -> bytes: ...
     @property
     def exit_code(self) -> int: ...
-    @property
-    def pid(self) -> int: ...
+
+    #
+    def __init__(
+        self,
+        cmd: list[str],
+        call_args: dict[str, Any],
+        stdin: _CommandIn,
+        stdout: _CommandOut,
+        stderr: _CommandOut,
+    ) -> None: ...
+
+    #
     def wait(self, timeout: float | None = ...) -> RunningCommand: ...
     def is_alive(self) -> bool: ...
-    def kill(self) -> None: ...
-    def kill_group(self) -> None: ...
-    def terminate(self) -> None: ...
-    def signal(self, sig: int) -> None: ...
-    def signal_group(self, sig: int) -> None: ...
+    def handle_command_exit_code(self, code: int) -> None: ...
+
+    #
     def __int__(self) -> int: ...
     def __float__(self) -> float: ...
+
+    #
     def __await__(self) -> Generator[Any, None, RunningCommand]: ...
     def __aiter__(self) -> AsyncIterator[str]: ...
-    def __enter__(self) -> None: ...
-    def __exit__(self, *args: Any) -> None: ...
+    async def __anext__(self) -> str: ...
+
+    #
+    def __iter__(self) -> Self: ...
     def __next__(self) -> str: ...
+
+    #
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
 
 # ---------------------------------------------------------------------------
 # Command — represents an un-run system program


### PR DESCRIPTION
After #788, this one fixes the 17 stubtest errors in  `sh.RunningCommand`, leaving us with a measly 8 stubtest errors. I'll take care of those in the next PR.

I also snuck in a small cleanup in `RunningCommand._OProc_attr_allowlist`, because theit was still referencing the three `*_thread_exc` properties of `OProc` that were removed in https://github.com/amoffat/sh/commit/1a65cd0 a while back. But if you prefer, I wouldn't mind moving this cleanup to a separate PR.