### PR TITLE
Run `stubtest` and `pyrefly coverage check` in CI (and tox)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
           uv run ruff format --check src/sh tests/
           uv run mypy src/sh/
           uv run stubtest sh
+          uv run pyrefly coverage check src/sh
           uv run rstcheck README.rst
 
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           uv run ruff check src/sh/ tests/
           uv run ruff format --check src/sh tests/
           uv run mypy src/sh/
+          uv run stubtest sh
           uv run rstcheck README.rst
 
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "sphinx-rtd-theme>=1.2.2",
     "pytest>=7.4.0",
     "mypy>=1.4.1",
+    "pyrefly>=1.1.1",
 ]
 
 [tool.ruff]

--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,5 @@ commands =
     ruff format --check src/sh tests/
     mypy src/sh/
     stubtest sh
+    pyrefly coverage check src/sh
     rstcheck README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,5 @@ commands =
     ruff check src/sh/ tests/
     ruff format --check src/sh tests/
     mypy src/sh/
+    stubtest sh
     rstcheck README.rst

--- a/uv.lock
+++ b/uv.lock
@@ -854,6 +854,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -972,6 +991,7 @@ source = { editable = "." }
 dev = [
     { name = "coverage" },
     { name = "mypy" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "rstcheck" },
     { name = "ruff" },
@@ -987,6 +1007,7 @@ dev = [
 dev = [
     { name = "coverage", specifier = ">=7.2.7" },
     { name = "mypy", specifier = ">=1.4.1" },
+    { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "rstcheck", specifier = ">=6.1.2" },
     { name = "ruff", specifier = ">=0.4" },


### PR DESCRIPTION
As promised in #791:

> I plan on working on adding stubtest to the CI pipeline so we can ensure that the stubs stay in sync with the runtime API.

... and so it shall be done.

Oh and while we're at it, it might also be a good idea to ensure 100% type coverage (i.e. ensure that everything in the public API is annotated). For that we could use `pyrefly coverage check`  ([docs](https://pyrefly.org/en/docs/report/); but don't mind the "experimental" status, which doesn't really apply anymore, ~and I think I'll go ahead and open a PR to remove that right now~ and I opened a PR for that: https://github.com/facebook/pyrefly/pull/4269):

```console
$ uvx pyrefly coverage check src/sh
 INFO type coverage 100.00% (178 of 178 typable)
```

When I remove a random annotation in the stubs, here's what you'll see:

```console
$ uv run stubtest sh
Success: no issues found in 1 module

$ uvx pyrefly coverage check src/sh
 WARN `sh.glob` is not fully typed [coverage-partial]
    --> src/sh/__init__.pyi:1393:1
     |
1393 | def glob(path, *args: Any, **kwargs: Any) -> list[str]: ...
     | -----------------------------------------------------------
     |
ERROR type coverage 99.44% (177 of 178 typable) is below the 100.00% threshold
```

And FWIW; we're also using it in numpy and scipy-stubs, and it has been very helpful, and was able to catch things that stubtest didn't catch.

So if you want I could also add that as well?