### PR TITLE
Fix repeated boolean overrides in baked commands

### DIFF
--- a/src/sh/__init__.py
+++ b/src/sh/__init__.py
@@ -1417,21 +1417,21 @@ class Command:
         if extra_args or extra_kwargs:
             all_layers.append((extra_args, extra_kwargs))
 
-        # Index: for each kwarg key, the earliest layer index where its value
-        # is False.  A True in layer i is suppressed iff first_false[key] > i,
+        # Index: for each kwarg key, the latest layer index where its value
+        # is False.  A True in layer i is suppressed iff last_false[key] > i,
         # i.e. a False override exists somewhere after that layer.  Building
         # this index in one O(L*K) pass eliminates the inner per-key scan.
-        first_false: dict = {}
+        last_false: dict = {}
         for i, (_, layer_kwargs) in enumerate(all_layers):
             for k, v in layer_kwargs.items():
-                if v is False and k not in first_false:
-                    first_false[k] = i
+                if v is False:
+                    last_false[k] = i
 
         result = []
         for i, (layer_args, layer_kwargs) in enumerate(all_layers):
             filtered_kwargs = {}
             for k, v in layer_kwargs.items():
-                if v is True and k in first_false and first_false[k] > i:
+                if v is True and k in last_false and last_false[k] > i:
                     continue
                 filtered_kwargs[k] = v
 

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1476,6 +1476,19 @@ sys.stdout.write(str(sys.argv[1:]))
         out = pythons.bake(py.name).bake(a=True).bake(a=False)()
         self.assertNotIn("'-a'", out)
 
+    def test_bake_repeated_boolean_override(self):
+        py = create_tmp_test("import sys; print(sys.argv[1:], end='')")
+        for key, flag in (("a", "-a"), ("verbose", "--verbose")):
+            with self.subTest(key=key):
+                enabled = pythons.bake(py.name, **{key: False}).bake(**{key: True})
+                self.assertEqual(enabled(**{key: False}), "[]")
+
+                disabled = enabled.bake(**{key: False})
+                self.assertEqual(disabled(), "[]")
+                self.assertNotIn(flag, str(disabled))
+                self.assertEqual(disabled(**{key: True}), str([flag]))
+                self.assertEqual(enabled(), str([flag]))
+
     def test_arg_preprocessor(self):
         py = create_tmp_test(
             """

--- a/tests/sh_test.py
+++ b/tests/sh_test.py
@@ -1485,7 +1485,7 @@ sys.stdout.write(str(sys.argv[1:]))
 
                 disabled = enabled.bake(**{key: False})
                 self.assertEqual(disabled(), "[]")
-                self.assertNotIn(flag, str(disabled))
+                self.assertEqual(str(disabled), str(pythons.bake(py.name)))
                 self.assertEqual(disabled(**{key: True}), str([flag]))
                 self.assertEqual(enabled(), str([flag]))
 


### PR DESCRIPTION
Follow-up to #770: after baking a flag as `False` and then `True`, a later `False` leaves it enabled. The index keeps the first `False` and misses later overrides. Track the last `False` so both `bake()` and call-time overrides remove earlier `True` flags.

The regression checks the child process's arguments for short and long flags, including disabling, re-enabling, and reusing the original baked command.
